### PR TITLE
feat(simulation): set up simulation tests with create did message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,4 +94,4 @@ endif
 ifneq ($(shell git rev-parse --abbrev-ref HEAD),main)
 	$(error you are not on the main branch. aborting)
 endif
-	git tag -s -a "$(shell git-chglog $(APP_VERSION))" -m "Changelog: https://github.com/allinbits/cosmos-cash/blob/main/CHANGELOG.md"
+	git tag -s -a "$(APP_VERSION)" -m "Changelog: https://github.com/allinbits/cosmos-cash/blob/main/CHANGELOG.md"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGES="./x/..."
-# build paramters 
+# build paramters
 BUILD_FOLDER = build
 APP_VERSION = $(git describe --tags --always)
 
@@ -36,6 +36,9 @@ go.sum: go.mod
 test:
 	@go test -mod=readonly $(PACKAGES) -cover -race
 
+sim:
+	@go test -benchmem -bench BenchmarkSimulation ./app -NumBlocks=200 -BlockSize 50 -Commit=true -Verbose=true -Enabled=true
+
 lint:
 	@echo "--> Running linter"
 	@golangci-lint run
@@ -45,10 +48,10 @@ lint:
 ###                           Chain Initialization                          ###
 ###############################################################################
 
-start-dev: install 
+start-dev: install
 	./scripts/seeds/00_start_chain.sh
 
-seed: 
+seed:
 	./scripts/seeds/01_identifier_seeds.sh
 
 ###############################################################################

--- a/app/app.go
+++ b/app/app.go
@@ -355,7 +355,7 @@ func New(
 		keys[did.StoreKey],
 		keys[did.MemStoreKey],
 	)
-	didModule := didmodule.NewAppModule(appCodec, app.DidKeeper)
+	didModule := didmodule.NewAppModule(appCodec, app.DidKeeper, app.AccountKeeper, app.BankKeeper)
 
 	// this line is used by starport scaffolding # stargate/app/keeperDefinition
 
@@ -453,7 +453,7 @@ func New(
 		evidence.NewAppModule(app.EvidenceKeeper),
 		ibc.NewAppModule(app.IBCKeeper),
 		transferModule,
-		// TODO: didModule,
+		didmodule.NewAppModule(appCodec, app.DidKeeper, app.AccountKeeper, app.BankKeeper),
 		// this line is used by starport scaffolding # stargate/app/appModule
 	)
 	app.sm.RegisterStoreDecoders()

--- a/app/simulation_test.go
+++ b/app/simulation_test.go
@@ -1,0 +1,113 @@
+package app_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	simulationtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/cosmos/cosmos-sdk/x/simulation"
+	"github.com/elesto-dao/elesto/app"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/starport/starport/pkg/cosmoscmd"
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmtypes "github.com/tendermint/tendermint/types"
+)
+
+func init() {
+	simapp.GetSimulatorFlags()
+}
+
+type SimApp interface {
+	cosmoscmd.App
+	GetBaseApp() *baseapp.BaseApp
+	AppCodec() codec.Codec
+	SimulationManager() *module.SimulationManager
+	ModuleAccountAddrs() map[string]bool
+	Name() string
+	LegacyAmino() *codec.LegacyAmino
+	BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock
+	EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock
+	InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain
+}
+
+var defaultConsensusParams = &abci.ConsensusParams{
+	Block: &abci.BlockParams{
+		MaxBytes: 200000,
+		MaxGas:   2000000,
+	},
+	Evidence: &tmproto.EvidenceParams{
+		MaxAgeNumBlocks: 302400,
+		MaxAgeDuration:  504 * time.Hour, // 3 weeks is the max duration
+		MaxBytes:        10000,
+	},
+	Validator: &tmproto.ValidatorParams{
+		PubKeyTypes: []string{
+			tmtypes.ABCIPubKeyTypeEd25519,
+		},
+	},
+}
+
+// BenchmarkSimulation run the chain simulation
+// Running using starport command:
+// `starport chain simulate -v --numBlocks 200 --blockSize 50`
+// Running as go benchmark test:
+// `go test -benchmem -run=^$ -bench ^BenchmarkSimulation ./app -NumBlocks=200 -BlockSize 50 -Commit=true -Verbose=true -Enabled=true`
+func BenchmarkSimulation(b *testing.B) {
+	simapp.FlagEnabledValue = true
+	simapp.FlagCommitValue = true
+
+	config, db, dir, logger, _, err := simapp.SetupSimulation("goleveldb-app-sim", "Simulation")
+	require.NoError(b, err, "simulation setup failed")
+
+	b.Cleanup(func() {
+		db.Close()
+		err = os.RemoveAll(dir)
+		require.NoError(b, err)
+	})
+
+	encoding := cosmoscmd.MakeEncodingConfig(app.ModuleBasics)
+
+	app := app.New(
+		logger,
+		db,
+		nil,
+		true,
+		map[int64]bool{},
+		app.DefaultNodeHome,
+		0,
+		encoding,
+		simapp.EmptyAppOptions{},
+	)
+
+	simApp, ok := app.(SimApp)
+	require.True(b, ok, "can't use simapp")
+
+	// Run randomized simulations
+	_, simParams, simErr := simulation.SimulateFromSeed(
+		b,
+		os.Stdout,
+		simApp.GetBaseApp(),
+		simapp.AppStateFn(simApp.AppCodec(), simApp.SimulationManager()),
+		simulationtypes.RandomAccounts,
+		simapp.SimulationOperations(simApp, simApp.AppCodec(), config),
+		simApp.ModuleAccountAddrs(),
+		config,
+		simApp.AppCodec(),
+	)
+
+	// export state and simParams before the simulation error is checked
+	err = simapp.CheckExportSimulation(simApp, config, simParams)
+	require.NoError(b, err)
+	require.NoError(b, simErr)
+
+	if config.Commit {
+		simapp.PrintStats(db)
+	}
+}

--- a/x/did/expected_keepers.go
+++ b/x/did/expected_keepers.go
@@ -1,0 +1,17 @@
+package did
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+// AccountKeeper defines the expected account keeper (noalias)
+type AccountKeeper interface {
+	GetAccount(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
+}
+
+// BankKeeper defines the expected interface needed to retrieve account balances.
+type BankKeeper interface {
+	SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
+	IsSendEnabledCoins(ctx sdk.Context, coins ...sdk.Coin) error
+}

--- a/x/did/module/module.go
+++ b/x/did/module/module.go
@@ -3,12 +3,14 @@ package did
 import ( // this line is used by starport scaffolding # 1
 	"context"
 	"encoding/json"
+	"math/rand"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
@@ -17,11 +19,13 @@ import ( // this line is used by starport scaffolding # 1
 	"github.com/elesto-dao/elesto/x/did"
 	"github.com/elesto-dao/elesto/x/did/client/cli"
 	"github.com/elesto-dao/elesto/x/did/keeper"
+	"github.com/elesto-dao/elesto/x/did/simulation"
 )
 
 var (
-	_ module.AppModule      = AppModule{}
-	_ module.AppModuleBasic = AppModuleBasic{}
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
 )
 
 // ----------------------------------------------------------------------------
@@ -96,13 +100,17 @@ func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 type AppModule struct {
 	AppModuleBasic
 
+	ak     did.AccountKeeper
+	bk     did.BankKeeper
 	keeper keeper.Keeper
 }
 
-func NewAppModule(cdc codec.Codec, keeper keeper.Keeper) AppModule {
+func NewAppModule(cdc codec.Codec, keeper keeper.Keeper, ak did.AccountKeeper, bk did.BankKeeper) AppModule {
 	return AppModule{
 		AppModuleBasic: NewAppModuleBasic(cdc),
 		keeper:         keeper,
+		ak:             ak,
+		bk:             bk,
 	}
 }
 
@@ -155,6 +163,41 @@ func (am AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.Valid
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
 func (AppModule) ConsensusVersion() uint64 { return 1 }
+
+// ____________________________________________________________________________
+
+// AppModuleSimulation functions
+
+// GenerateGenesisState creates a randomized GenState of the authz module.
+func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
+	simulation.RandomizedGenState(simState)
+}
+
+// ProposalContents returns all the authz content functions used to
+// simulate governance proposals.
+func (am AppModule) ProposalContents(simState module.SimulationState) []simtypes.WeightedProposalContent {
+	return nil
+}
+
+// RandomizedParams creates randomized authz param changes for the simulator.
+func (AppModule) RandomizedParams(r *rand.Rand) []simtypes.ParamChange {
+	return nil
+}
+
+// RegisterStoreDecoder registers a decoder for authz module's types
+func (am AppModule) RegisterStoreDecoder(sdr sdk.StoreDecoderRegistry) {
+	sdr[did.StoreKey] = simulation.NewDecodeStore(am.cdc)
+}
+
+// WeightedOperations returns the all the gov module operations with their respective weights.
+func (am AppModule) WeightedOperations(simState module.SimulationState) []simtypes.WeightedOperation {
+	return simulation.WeightedOperations(
+		simState,
+		am.keeper,
+		am.bk,
+		am.ak,
+	)
+}
 
 // ----------------------------------------------------------------------------
 // Deprecation notice

--- a/x/did/msg.go
+++ b/x/did/msg.go
@@ -4,11 +4,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// msg types
-const (
-	TypeMsgCreateDidDocument = "create-did"
-)
-
 var _ sdk.Msg = &MsgCreateDidDocument{}
 
 // NewMsgCreateDidDocument creates a new MsgCreateDidDocument instance
@@ -32,12 +27,14 @@ func (MsgCreateDidDocument) Route() string {
 }
 
 // Type implements sdk.Msg
-func (MsgCreateDidDocument) Type() string {
-	return TypeMsgCreateDidDocument
+func (msg MsgCreateDidDocument) Type() string {
+	return sdk.MsgTypeURL(&msg)
 }
 
+// GetSignBytes implements the LegacyMsg.GetSignBytes method.
 func (msg MsgCreateDidDocument) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
+	bz := ModuleCdc.MustMarshalJSON(&msg)
+	return sdk.MustSortJSON(bz)
 }
 
 // GetSigners implements sdk.Msg
@@ -78,8 +75,9 @@ func (MsgUpdateDidDocument) Type() string {
 	return TypeMsgUpdateDidDocument
 }
 
+// GetSignBytes implements the LegacyMsg.GetSignBytes method.
 func (msg MsgUpdateDidDocument) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
+	panic("TODO: needed in simulations for fuzz testing")
 }
 
 // GetSigners implements sdk.Msg
@@ -124,8 +122,9 @@ func (MsgAddVerification) Type() string {
 	return TypeMsgAddVerification
 }
 
+// GetSignBytes implements the LegacyMsg.GetSignBytes method.
 func (msg MsgAddVerification) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
+	panic("TODO: needed in simulations for fuzz testing")
 }
 
 // GetSigners implements sdk.Msg
@@ -171,8 +170,9 @@ func (MsgRevokeVerification) Type() string {
 	return TypeMsgRevokeVerification
 }
 
+// GetSignBytes implements the LegacyMsg.GetSignBytes method.
 func (msg MsgRevokeVerification) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
+	panic("TODO: needed in simulations for fuzz testing")
 }
 
 // GetSigners implements sdk.Msg
@@ -216,8 +216,9 @@ func (MsgSetVerificationRelationships) Type() string {
 	return TypeMsgSetVerificationRelationships
 }
 
+// GetSignBytes implements the LegacyMsg.GetSignBytes method.
 func (msg MsgSetVerificationRelationships) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
+	panic("TODO: needed in simulations for fuzz testing")
 }
 
 // GetSigners implements sdk.Msg
@@ -263,8 +264,9 @@ func (MsgAddService) Type() string {
 	return TypeMsgAddService
 }
 
+// GetSignBytes implements the LegacyMsg.GetSignBytes method.
 func (msg MsgAddService) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
+	panic("TODO: needed in simulations for fuzz testing")
 }
 
 // GetSigners implements sdk.Msg
@@ -307,8 +309,9 @@ func (MsgDeleteService) Type() string {
 	return TypeMsgDeleteService
 }
 
+// GetSignBytes implements the LegacyMsg.GetSignBytes method.
 func (msg MsgDeleteService) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
+	panic("TODO: needed in simulations for fuzz testing")
 }
 
 // GetSigners implements sdk.Msg
@@ -351,8 +354,9 @@ func (MsgAddController) Type() string {
 	return TypeMsgAddController
 }
 
+// GetSignBytes implements the LegacyMsg.GetSignBytes method.
 func (msg MsgAddController) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
+	panic("TODO: needed in simulations for fuzz testing")
 }
 
 // GetSigners implements sdk.Msg
@@ -385,7 +389,7 @@ func NewMsgDeleteController(
 	}
 }
 
-// Route implements sdk.Msg
+//// Route implements sdk.Msg
 func (MsgDeleteController) Route() string {
 	return RouterKey
 }
@@ -395,8 +399,9 @@ func (MsgDeleteController) Type() string {
 	return TypeMsgDeleteController
 }
 
+// GetSignBytes implements the LegacyMsg.GetSignBytes method.
 func (msg MsgDeleteController) GetSignBytes() []byte {
-	panic("IBC messages do not support amino")
+	panic("TODO: needed in simulations for fuzz testing")
 }
 
 // GetSigners implements sdk.Msg

--- a/x/did/msg_test.go
+++ b/x/did/msg_test.go
@@ -11,11 +11,11 @@ func TestMsgCreateDidDocument_Route(t *testing.T) {
 }
 
 func TestMsgCreateDidDocument_Type(t *testing.T) {
-	assert.Equalf(t, TypeMsgCreateDidDocument, MsgCreateDidDocument{}.Type(), "Type()")
+	assert.Equalf(t, sdk.MsgTypeURL(&MsgCreateDidDocument{}), MsgCreateDidDocument{}.Type(), "Type()")
 }
 
 func TestMsgCreateDidDocument_GetSignBytes(t *testing.T) {
-	assert.Panicsf(t, func() { MsgCreateDidDocument{}.GetSignBytes() }, "GetSignBytes()")
+	assert.Equal(t, sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&MsgCreateDidDocument{})), MsgCreateDidDocument{}.GetSignBytes(), "GetSignBytes()")
 }
 
 func TestMsgCreateDidDocument_GetSigners(t *testing.T) {

--- a/x/did/simulation/decoder.go
+++ b/x/did/simulation/decoder.go
@@ -1,0 +1,27 @@
+package simulation
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/types/kv"
+
+	"github.com/elesto-dao/elesto/x/did"
+)
+
+// NewDecodeStore returns a decoder function closure that umarshals the KVPair's
+// Value to the corresponding did type.
+func NewDecodeStore(cdc codec.Codec) func(kvA, kvB kv.Pair) string {
+	return func(kvA, kvB kv.Pair) string {
+		switch {
+		case bytes.Equal(kvA.Key[:1], did.DidDocumentKey):
+			var didA, didB did.DidDocument
+			cdc.MustUnmarshal(kvA.Value, &didA)
+			cdc.MustUnmarshal(kvB.Value, &didB)
+			return fmt.Sprintf("%v\n%v", didA, didB)
+		default:
+			panic(fmt.Sprintf("invalid didDoc key %X", kvA.Key))
+		}
+	}
+}

--- a/x/did/simulation/genesis.go
+++ b/x/did/simulation/genesis.go
@@ -1,0 +1,9 @@
+package simulation
+
+import (
+	"github.com/cosmos/cosmos-sdk/types/module"
+)
+
+// RandomizedGenState generates a random GenesisState for did.
+func RandomizedGenState(simState *module.SimulationState) {
+}

--- a/x/did/simulation/operations.go
+++ b/x/did/simulation/operations.go
@@ -1,0 +1,63 @@
+package simulation
+
+import (
+	"math/rand"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/cosmos/cosmos-sdk/x/simulation"
+
+	"github.com/elesto-dao/elesto/x/did"
+	"github.com/elesto-dao/elesto/x/did/keeper"
+)
+
+var (
+	TypeMsgCreateDidDocument = sdk.MsgTypeURL(&did.MsgCreateDidDocument{})
+)
+
+const (
+	opWeightMsgCreateDidDocument = "op_weight_msg_create_did_document"
+
+	// TODO: Determine the simulation weight value
+	defaultWeightMsgCreateDidDocument int = 100
+
+	// this line is used by starport scaffolding # simapp/module/const
+)
+
+// GenerateGenesisState creates a randomized GenState of the module
+func GenerateGenesisState(simState *module.SimulationState) {
+}
+
+// ProposalContents doesn't return any content functions for governance proposals
+func ProposalContents(_ module.SimulationState) []simtypes.WeightedProposalContent {
+	return nil
+}
+
+// RandomizedParams creates randomized  param changes for the simulator
+func RandomizedParams(_ *rand.Rand) []simtypes.ParamChange {
+	return []simtypes.ParamChange{}
+}
+
+// RegisterStoreDecoder registers a decoder
+func RegisterStoreDecoder(_ sdk.StoreDecoderRegistry) {}
+
+// WeightedOperations returns the all the gov module operations with their respective weights.
+func WeightedOperations(simState module.SimulationState, didKeeper keeper.Keeper, bk did.BankKeeper, ak did.AccountKeeper) []simtypes.WeightedOperation {
+	operations := make([]simtypes.WeightedOperation, 0)
+
+	var weightMsgCreateDidDocument int
+	simState.AppParams.GetOrGenerate(simState.Cdc, opWeightMsgCreateDidDocument, &weightMsgCreateDidDocument, nil,
+		func(_ *rand.Rand) {
+			weightMsgCreateDidDocument = defaultWeightMsgCreateDidDocument
+		},
+	)
+	operations = append(operations, simulation.NewWeightedOperation(
+		weightMsgCreateDidDocument,
+		SimulateMsgCreateDidDocument(didKeeper, bk, ak),
+	))
+
+	// this line is used by starport scaffolding # simapp/module/operation
+
+	return operations
+}

--- a/x/did/simulation/simulation.go
+++ b/x/did/simulation/simulation.go
@@ -1,0 +1,78 @@
+package simulation
+
+import (
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/cosmos/cosmos-sdk/x/simulation"
+
+	"github.com/elesto-dao/elesto/x/did"
+	"github.com/elesto-dao/elesto/x/did/keeper"
+)
+
+// SimulateMsgCreateDidDocument simulates a MsgCreateDidDocument message
+func SimulateMsgCreateDidDocument(k keeper.Keeper, bk did.BankKeeper, ak did.AccountKeeper) simtypes.Operation {
+	return func(
+		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		didOwner, _ := simtypes.RandomAcc(r, accs)
+		ownerAddress := didOwner.Address.String()
+		didID := did.NewChainDID(ctx.ChainID(), ownerAddress)
+		vmID := didID.NewVerificationMethodID(ownerAddress)
+		vmType := did.DIDVMethodTypeEcdsaSecp256k1VerificationKey2019
+		auth := did.NewVerification(
+			did.NewVerificationMethod(
+				vmID,
+				didID,
+				did.NewPublicKeyMultibase(didOwner.PubKey.Bytes(), vmType),
+			),
+			[]string{did.Authentication},
+			nil,
+		)
+
+		didDoc, found := k.GetDidDocument(ctx, []byte(didID))
+		d, _ := did.NewDidDocument(didID.String(), did.WithVerifications(auth))
+		msg := did.NewMsgCreateDidDocument(
+			didID.String(),
+			did.Verifications{auth},
+			did.Services{},
+			ownerAddress,
+		)
+
+		if found {
+			// check the store matches the input
+			if !didDoc.Equal(d) {
+				// return an error that will stop simulation
+				return simtypes.NoOpMsg(
+						did.ModuleName,
+						TypeMsgCreateDidDocument,
+						"did found but not matched",
+					),
+					nil,
+					sdkerrors.Wrapf(sdkerrors.ErrNotFound, "did found but not matched")
+
+			}
+			return simtypes.NoOpMsg(did.ModuleName, TypeMsgCreateDidDocument, "dids found"), nil, nil
+		}
+
+		txCtx := simulation.OperationInput{
+			R:               r,
+			App:             app,
+			TxGen:           simappparams.MakeTestEncodingConfig().TxConfig,
+			Cdc:             nil,
+			Msg:             msg,
+			MsgType:         TypeMsgCreateDidDocument,
+			Context:         ctx,
+			SimAccount:      didOwner,
+			AccountKeeper:   ak,
+			Bankkeeper:      bk,
+			ModuleName:      did.ModuleName,
+			CoinsSpentInMsg: sdk.NewCoins(),
+		}
+		return simulation.GenAndDeliverTxWithRandFees(txCtx)
+	}
+}


### PR DESCRIPTION
### Description

- Added simulation framework to elesto project
- Added simulation for create did message

### How to test

- `make sim`
or
- `go test -benchmem -run=^$ -bench BenchmarkSimulation ./app -NumBlocks=100 -BlockSize 50 -Commit=true -Verbose=true -Enabled=true`

### What it looks like

```
 "did": {
  "/allinbits.cosmoscash.did.MsgCreateDidDocument": {
   "failure": 18,
   "ok": 186
  }
 },
```

```
LevelDB Stats
Compactions
 Level |   Tables   |    Size(MB)   |    Time(sec)  |    Read(MB)   |   Write(MB)
-------+------------+---------------+---------------+---------------+---------------
   0   |          4 |      10.60058 |       0.36525 |       0.00000 |      56.55647
   1   |         23 |      46.41385 |       2.58553 |     302.35150 |     302.80946
-------+------------+---------------+---------------+---------------+---------------
 Total |         27 |      57.01443 |       2.95078 |     302.35150 |     359.36593

```

### TODO

- [x] MsgCreateDidDocument
- [ ] MsgUpdateDidDocument
- [ ] MsgAddVerification
- [ ] MsgRevokeVerification
- [ ] MsgSetVerificationRelationships
- [ ] MsgAddService
- [ ] MsgDeleteService
- [ ] MsgAddController
- [ ] MsgDeleteController
