### PR TITLE
feat(simulation): add simulation for revoke verification msg

### DIFF
--- a/x/did/msg.go
+++ b/x/did/msg.go
@@ -184,10 +184,8 @@ func (msg MsgRevokeVerification) GetSigners() []sdk.AccAddress {
 // --------------------------
 // SET VERIFICATION RELATIONSHIPS
 // --------------------------
-// msg types
-const (
-	TypeMsgSetVerificationRelationships = "set-verification-relationships"
-)
+
+var _ sdk.Msg = &MsgSetVerificationRelationships{}
 
 func NewMsgSetVerificationRelationships(
 	id string,
@@ -209,13 +207,14 @@ func (MsgSetVerificationRelationships) Route() string {
 }
 
 // Type implements sdk.Msg
-func (MsgSetVerificationRelationships) Type() string {
-	return TypeMsgSetVerificationRelationships
+func (msg MsgSetVerificationRelationships) Type() string {
+	return sdk.MsgTypeURL(&msg)
 }
 
 // GetSignBytes implements the LegacyMsg.GetSignBytes method.
-func (MsgSetVerificationRelationships) GetSignBytes() []byte {
-	panic("TODO: needed in simulations for fuzz testing")
+func (msg MsgSetVerificationRelationships) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(&msg)
+	return sdk.MustSortJSON(bz)
 }
 
 // GetSigners implements sdk.Msg

--- a/x/did/msg.go
+++ b/x/did/msg.go
@@ -231,11 +231,6 @@ func (msg MsgSetVerificationRelationships) GetSigners() []sdk.AccAddress {
 // ADD SERVICE
 // --------------------------
 
-// msg types
-const (
-	TypeMsgAddService = "add-service"
-)
-
 var _ sdk.Msg = &MsgAddService{}
 
 // NewMsgAddService creates a new MsgAddService instance
@@ -257,13 +252,14 @@ func (MsgAddService) Route() string {
 }
 
 // Type implements sdk.Msg
-func (MsgAddService) Type() string {
-	return TypeMsgAddService
+func (msg MsgAddService) Type() string {
+	return sdk.MsgTypeURL(&msg)
 }
 
 // GetSignBytes implements the LegacyMsg.GetSignBytes method.
-func (MsgAddService) GetSignBytes() []byte {
-	panic("TODO: needed in simulations for fuzz testing")
+func (msg MsgAddService) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(&msg)
+	return sdk.MustSortJSON(bz)
 }
 
 // GetSigners implements sdk.Msg
@@ -278,11 +274,6 @@ func (msg MsgAddService) GetSigners() []sdk.AccAddress {
 // --------------------------
 // DELETE SERVICE
 // --------------------------
-
-// msg types
-const (
-	TypeMsgDeleteService = "delete-service"
-)
 
 func NewMsgDeleteService(
 	id string,
@@ -302,13 +293,14 @@ func (MsgDeleteService) Route() string {
 }
 
 // Type implements sdk.Msg
-func (MsgDeleteService) Type() string {
-	return TypeMsgDeleteService
+func (msg MsgDeleteService) Type() string {
+	return sdk.MsgTypeURL(&msg)
 }
 
 // GetSignBytes implements the LegacyMsg.GetSignBytes method.
-func (MsgDeleteService) GetSignBytes() []byte {
-	panic("TODO: needed in simulations for fuzz testing")
+func (msg MsgDeleteService) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(&msg)
+	return sdk.MustSortJSON(bz)
 }
 
 // GetSigners implements sdk.Msg

--- a/x/did/msg.go
+++ b/x/did/msg.go
@@ -4,6 +4,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+// --------------------------
+// CREATE IDENTIFIER
+// --------------------------
+
 var _ sdk.Msg = &MsgCreateDidDocument{}
 
 // NewMsgCreateDidDocument creates a new MsgCreateDidDocument instance
@@ -137,11 +141,6 @@ func (msg MsgAddVerification) GetSigners() []sdk.AccAddress {
 // REVOKE VERIFICATION
 // --------------------------
 
-// msg types
-const (
-	TypeMsgRevokeVerification = "revoke-verification"
-)
-
 var _ sdk.Msg = &MsgRevokeVerification{}
 
 // NewMsgRevokeVerification creates a new MsgRevokeVerification instance
@@ -163,13 +162,14 @@ func (MsgRevokeVerification) Route() string {
 }
 
 // Type implements sdk.Msg
-func (MsgRevokeVerification) Type() string {
-	return TypeMsgRevokeVerification
+func (msg MsgRevokeVerification) Type() string {
+	return sdk.MsgTypeURL(&msg)
 }
 
 // GetSignBytes implements the LegacyMsg.GetSignBytes method.
-func (MsgRevokeVerification) GetSignBytes() []byte {
-	panic("TODO: needed in simulations for fuzz testing")
+func (msg MsgRevokeVerification) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(&msg)
+	return sdk.MustSortJSON(bz)
 }
 
 // GetSigners implements sdk.Msg

--- a/x/did/msg_test.go
+++ b/x/did/msg_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 )
 
+// --------------------------
+// CREATE IDENTIFIER
+// --------------------------
+
 func TestMsgCreateDidDocument_Route(t *testing.T) {
 	assert.Equalf(t, ModuleName, MsgCreateDidDocument{}.Route(), "Route()")
 }
@@ -27,6 +31,10 @@ func TestMsgCreateDidDocument_GetSigners(t *testing.T) {
 	)
 	assert.Panics(t, func() { MsgCreateDidDocument{Signer: "invalid"}.GetSigners() })
 }
+
+// --------------------------
+// UPDATE IDENTIFIER
+// --------------------------
 
 func TestMsgUpdateDidDocument_Route(t *testing.T) {
 	assert.Equalf(t, ModuleName, MsgUpdateDidDocument{}.Route(), "Route()")
@@ -50,6 +58,10 @@ func TestMsgUpdateDidDocument_GetSigners(t *testing.T) {
 	assert.Panics(t, func() { MsgUpdateDidDocument{Signer: "invalid"}.GetSigners() })
 }
 
+// --------------------------
+// ADD VERIFICATION
+// --------------------------
+
 func TestMsgAddVerification_Route(t *testing.T) {
 	assert.Equalf(t, ModuleName, MsgAddVerification{}.Route(), "Route()")
 }
@@ -72,16 +84,20 @@ func TestMsgAddVerification_GetSigners(t *testing.T) {
 	assert.Panics(t, func() { MsgAddVerification{Signer: "invalid"}.GetSigners() })
 }
 
+// --------------------------
+// REVOKE VERIFICATION
+// --------------------------
+
 func TestMsgRevokeVerification_Route(t *testing.T) {
 	assert.Equalf(t, ModuleName, MsgRevokeVerification{}.Route(), "Route()")
 }
 
 func TestMsgRevokeVerification_Type(t *testing.T) {
-	assert.Equalf(t, TypeMsgRevokeVerification, MsgRevokeVerification{}.Type(), "Type()")
+	assert.Equalf(t, sdk.MsgTypeURL(&MsgRevokeVerification{}), MsgRevokeVerification{}.Type(), "Type()")
 }
 
 func TestMsgRevokeVerification_GetSignBytes(t *testing.T) {
-	assert.Panicsf(t, func() { MsgRevokeVerification{}.GetSignBytes() }, "GetSignBytes()")
+	assert.Equal(t, sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&MsgRevokeVerification{})), MsgRevokeVerification{}.GetSignBytes(), "GetSignBytes()")
 }
 
 func TestMsgRevokeVerification_GetSigners(t *testing.T) {
@@ -93,6 +109,10 @@ func TestMsgRevokeVerification_GetSigners(t *testing.T) {
 	)
 	assert.Panics(t, func() { MsgRevokeVerification{Signer: "invalid"}.GetSigners() })
 }
+
+// --------------------------
+// SET VERIFICATION RELATIONSHIPS
+// --------------------------
 
 func TestMsgSetVerificationRelationships_Route(t *testing.T) {
 	assert.Equalf(t, ModuleName, MsgSetVerificationRelationships{}.Route(), "Route()")
@@ -116,6 +136,10 @@ func TestMsgSetVerificationRelationships_GetSigners(t *testing.T) {
 	assert.Panics(t, func() { MsgSetVerificationRelationships{Signer: "invalid"}.GetSigners() })
 }
 
+// --------------------------
+// DELETE SERVICE
+// --------------------------
+
 func TestMsgDeleteService_Route(t *testing.T) {
 	assert.Equalf(t, ModuleName, MsgDeleteService{}.Route(), "Route()")
 }
@@ -137,6 +161,10 @@ func TestMsgDeleteService_GetSigners(t *testing.T) {
 	)
 	assert.Panics(t, func() { MsgDeleteService{Signer: "invalid"}.GetSigners() })
 }
+
+// --------------------------
+// ADD SERVICE
+// --------------------------
 
 func TestMsgAddService_Route(t *testing.T) {
 	assert.Equalf(t, ModuleName, MsgAddService{}.Route(), "Route()")
@@ -160,6 +188,10 @@ func TestMsgAddService_GetSigners(t *testing.T) {
 	assert.Panics(t, func() { MsgAddService{Signer: "invalid"}.GetSigners() })
 }
 
+// --------------------------
+// ADD CONTROLLER
+// --------------------------
+
 func TestMsgAddController_Route(t *testing.T) {
 	assert.Equalf(t, ModuleName, MsgAddController{}.Route(), "Route()")
 }
@@ -181,6 +213,10 @@ func TestMsgAddController_GetSigners(t *testing.T) {
 	)
 	assert.Panics(t, func() { MsgAddController{Signer: "invalid"}.GetSigners() })
 }
+
+// --------------------------
+// DELETE CONTROLLER
+// --------------------------
 
 func TestMsgDeleteController_Route(t *testing.T) {
 	assert.Equalf(t, ModuleName, MsgDeleteController{}.Route(), "Route()")

--- a/x/did/msg_test.go
+++ b/x/did/msg_test.go
@@ -119,11 +119,11 @@ func TestMsgSetVerificationRelationships_Route(t *testing.T) {
 }
 
 func TestMsgSetVerificationRelationships_Type(t *testing.T) {
-	assert.Equalf(t, TypeMsgSetVerificationRelationships, MsgSetVerificationRelationships{}.Type(), "Type()")
+	assert.Equalf(t, sdk.MsgTypeURL(&MsgSetVerificationRelationships{}), MsgSetVerificationRelationships{}.Type(), "Type()")
 }
 
 func TestMsgSetVerificationRelationships_GetSignBytes(t *testing.T) {
-	assert.Panicsf(t, func() { MsgSetVerificationRelationships{}.GetSignBytes() }, "GetSignBytes()")
+	assert.Equal(t, sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&MsgSetVerificationRelationships{})), MsgSetVerificationRelationships{}.GetSignBytes(), "GetSignBytes()")
 }
 
 func TestMsgSetVerificationRelationships_GetSigners(t *testing.T) {

--- a/x/did/msg_test.go
+++ b/x/did/msg_test.go
@@ -145,11 +145,11 @@ func TestMsgDeleteService_Route(t *testing.T) {
 }
 
 func TestMsgDeleteService_Type(t *testing.T) {
-	assert.Equalf(t, TypeMsgDeleteService, MsgDeleteService{}.Type(), "Type()")
+	assert.Equalf(t, sdk.MsgTypeURL(&MsgDeleteService{}), MsgDeleteService{}.Type(), "Type()")
 }
 
 func TestMsgDeleteService_GetSignBytes(t *testing.T) {
-	assert.Panicsf(t, func() { MsgDeleteService{}.GetSignBytes() }, "GetSignBytes()")
+	assert.Equal(t, sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&MsgDeleteService{})), MsgDeleteService{}.GetSignBytes(), "GetSignBytes()")
 }
 
 func TestMsgDeleteService_GetSigners(t *testing.T) {
@@ -171,11 +171,11 @@ func TestMsgAddService_Route(t *testing.T) {
 }
 
 func TestMsgAddService_Type(t *testing.T) {
-	assert.Equalf(t, TypeMsgAddService, MsgAddService{}.Type(), "Type()")
+	assert.Equalf(t, sdk.MsgTypeURL(&MsgAddService{}), MsgAddService{}.Type(), "Type()")
 }
 
 func TestMsgAddService_GetSignBytes(t *testing.T) {
-	assert.Panicsf(t, func() { MsgAddService{}.GetSignBytes() }, "GetSignBytes()")
+	assert.Equal(t, sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&MsgAddService{})), MsgAddService{}.GetSignBytes(), "GetSignBytes()")
 }
 
 func TestMsgAddService_GetSigners(t *testing.T) {

--- a/x/did/simulation/operations_test.go
+++ b/x/did/simulation/operations_test.go
@@ -83,6 +83,8 @@ func (suite *SimTestSuite) TestWeightedOperations() {
 		{100, did.ModuleName, simulation.TypeMsgCreateDidDocument},
 		{100, did.ModuleName, simulation.TypeMsgAddVerification},
 		{100, did.ModuleName, simulation.TypeMsgRevokeVerification},
+		{100, did.ModuleName, simulation.TypeMsgAddService},
+		{100, did.ModuleName, simulation.TypeMsgDeleteService},
 	}
 
 	for i, w := range weightedOps {
@@ -208,6 +210,80 @@ func (suite *SimTestSuite) TestSimulateRevokeVerification() {
 	suite.Require().NoError(err)
 
 	var msg did.MsgRevokeVerification
+	suite.app.AppCodec().UnmarshalJSON(operationMsg.Msg, &msg)
+
+	// TODO: check for success, needs a did in the store
+	// check the message was unsuccessful
+	suite.Require().False(operationMsg.OK)
+	suite.Require().Equal("", msg.Signer)
+
+	suite.Require().Len(futureOperations, 0)
+}
+
+func (suite *SimTestSuite) TestSimulateAddService() {
+	s := rand.NewSource(1)
+	r := rand.New(s)
+	accounts := suite.getTestingAccounts(r, 2)
+	blockTime := time.Now().UTC()
+	ctx := suite.ctx.WithBlockTime(blockTime)
+
+	suite.app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: suite.app.LastBlockHeight() + 1, AppHash: suite.app.LastCommitID().Hash}})
+
+	// begin a new block
+	suite.app.BeginBlock(
+		abci.RequestBeginBlock{
+			Header: tmproto.Header{
+				Height:  suite.app.LastBlockHeight() + 1,
+				AppHash: suite.app.LastCommitID().Hash,
+			},
+		})
+
+	// TODO: create a DID for this account and add it to the store
+	// signer := accounts[0]
+
+	// execute operation
+	op := simulation.SimulateMsgAddService(suite.app.DidKeeper, suite.app.BankKeeper, suite.app.AccountKeeper)
+	operationMsg, futureOperations, err := op(r, suite.app.BaseApp, ctx, accounts, "")
+	suite.Require().NoError(err)
+
+	var msg did.MsgAddService
+	suite.app.AppCodec().UnmarshalJSON(operationMsg.Msg, &msg)
+
+	// TODO: check for success, needs a did in the store
+	// check the message was unsuccessful
+	suite.Require().False(operationMsg.OK)
+	suite.Require().Equal("", msg.Signer)
+
+	suite.Require().Len(futureOperations, 0)
+}
+
+func (suite *SimTestSuite) TestSimulateDeleteService() {
+	s := rand.NewSource(1)
+	r := rand.New(s)
+	accounts := suite.getTestingAccounts(r, 2)
+	blockTime := time.Now().UTC()
+	ctx := suite.ctx.WithBlockTime(blockTime)
+
+	suite.app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: suite.app.LastBlockHeight() + 1, AppHash: suite.app.LastCommitID().Hash}})
+
+	// begin a new block
+	suite.app.BeginBlock(
+		abci.RequestBeginBlock{
+			Header: tmproto.Header{
+				Height:  suite.app.LastBlockHeight() + 1,
+				AppHash: suite.app.LastCommitID().Hash,
+			},
+		})
+
+	// TODO: create a DID for this account and add it to the store
+	// signer := accounts[0]
+
+	// execute operation
+	op := simulation.SimulateMsgDeleteService(suite.app.DidKeeper, suite.app.BankKeeper, suite.app.AccountKeeper)
+	operationMsg, futureOperations, err := op(r, suite.app.BaseApp, ctx, accounts, "")
+	suite.Require().NoError(err)
+
+	var msg did.MsgDeleteService
 	suite.app.AppCodec().UnmarshalJSON(operationMsg.Msg, &msg)
 
 	// TODO: check for success, needs a did in the store

--- a/x/did/simulation/operations_test.go
+++ b/x/did/simulation/operations_test.go
@@ -82,6 +82,7 @@ func (suite *SimTestSuite) TestWeightedOperations() {
 	}{
 		{100, did.ModuleName, simulation.TypeMsgCreateDidDocument},
 		{100, did.ModuleName, simulation.TypeMsgAddVerification},
+		{100, did.ModuleName, simulation.TypeMsgRevokeVerification},
 	}
 
 	for i, w := range weightedOps {
@@ -173,7 +174,43 @@ func (suite *SimTestSuite) TestSimulateAddVerification() {
 	suite.app.AppCodec().UnmarshalJSON(operationMsg.Msg, &msg)
 
 	// TODO: check for success, needs a did in the store
+	// check the message was unsuccessful
+	suite.Require().False(operationMsg.OK)
+	suite.Require().Equal("", msg.Signer)
 
+	suite.Require().Len(futureOperations, 0)
+}
+
+func (suite *SimTestSuite) TestSimulateRevokeVerification() {
+	s := rand.NewSource(1)
+	r := rand.New(s)
+	accounts := suite.getTestingAccounts(r, 2)
+	blockTime := time.Now().UTC()
+	ctx := suite.ctx.WithBlockTime(blockTime)
+
+	suite.app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: suite.app.LastBlockHeight() + 1, AppHash: suite.app.LastCommitID().Hash}})
+
+	// begin a new block
+	suite.app.BeginBlock(
+		abci.RequestBeginBlock{
+			Header: tmproto.Header{
+				Height:  suite.app.LastBlockHeight() + 1,
+				AppHash: suite.app.LastCommitID().Hash,
+			},
+		})
+
+	// TODO: create a DID for this account and add it to the store
+	// signer := accounts[0]
+
+	// execute operation
+	op := simulation.SimulateMsgRevokeVerification(suite.app.DidKeeper, suite.app.BankKeeper, suite.app.AccountKeeper)
+	operationMsg, futureOperations, err := op(r, suite.app.BaseApp, ctx, accounts, "")
+	suite.Require().NoError(err)
+
+	var msg did.MsgRevokeVerification
+	suite.app.AppCodec().UnmarshalJSON(operationMsg.Msg, &msg)
+
+	// TODO: check for success, needs a did in the store
 	// check the message was unsuccessful
 	suite.Require().False(operationMsg.OK)
 	suite.Require().Equal("", msg.Signer)


### PR DESCRIPTION
### Description

- simulation for revoke verification message

### How to test

- `make sim`

### Output

```json
 "did": {
  "/elestodao.elesto.did.MsgAddVerification": {
   "failure": 285,
   "ok": 44
  },
  "/elestodao.elesto.did.MsgCreateDidDocument": {
   "failure": 46,
   "ok": 280
  },
  "/elestodao.elesto.did.MsgRevokeVerification": {
   "failure": 333,
   "ok": 3
  }
 },
```