### PR TITLE
feat(simulation): add simulation for set verification relationships msg

### DIFF
--- a/x/did/msg.go
+++ b/x/did/msg.go
@@ -184,10 +184,8 @@ func (msg MsgRevokeVerification) GetSigners() []sdk.AccAddress {
 // --------------------------
 // SET VERIFICATION RELATIONSHIPS
 // --------------------------
-// msg types
-const (
-	TypeMsgSetVerificationRelationships = "set-verification-relationships"
-)
+
+var _ sdk.Msg = &MsgSetVerificationRelationships{}
 
 func NewMsgSetVerificationRelationships(
 	id string,
@@ -209,13 +207,14 @@ func (MsgSetVerificationRelationships) Route() string {
 }
 
 // Type implements sdk.Msg
-func (MsgSetVerificationRelationships) Type() string {
-	return TypeMsgSetVerificationRelationships
+func (msg MsgSetVerificationRelationships) Type() string {
+	return sdk.MsgTypeURL(&msg)
 }
 
 // GetSignBytes implements the LegacyMsg.GetSignBytes method.
-func (MsgSetVerificationRelationships) GetSignBytes() []byte {
-	panic("TODO: needed in simulations for fuzz testing")
+func (msg MsgSetVerificationRelationships) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(&msg)
+	return sdk.MustSortJSON(bz)
 }
 
 // GetSigners implements sdk.Msg

--- a/x/did/msg_test.go
+++ b/x/did/msg_test.go
@@ -119,11 +119,11 @@ func TestMsgSetVerificationRelationships_Route(t *testing.T) {
 }
 
 func TestMsgSetVerificationRelationships_Type(t *testing.T) {
-	assert.Equalf(t, TypeMsgSetVerificationRelationships, MsgSetVerificationRelationships{}.Type(), "Type()")
+	assert.Equalf(t, sdk.MsgTypeURL(&MsgSetVerificationRelationships{}), MsgSetVerificationRelationships{}.Type(), "Type()")
 }
 
 func TestMsgSetVerificationRelationships_GetSignBytes(t *testing.T) {
-	assert.Panicsf(t, func() { MsgSetVerificationRelationships{}.GetSignBytes() }, "GetSignBytes()")
+	assert.Equal(t, sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&MsgSetVerificationRelationships{})), MsgSetVerificationRelationships{}.GetSignBytes(), "GetSignBytes()")
 }
 
 func TestMsgSetVerificationRelationships_GetSigners(t *testing.T) {


### PR DESCRIPTION
### Description

- simulation for setting verification relationships

### How to test

- `make sim`

### Output
```json
 "did": {
  "/elestodao.elesto.did.MsgAddService": {
   "failure": 291,
   "ok": 40
  },
  "/elestodao.elesto.did.MsgAddVerification": {
   "failure": 279,
   "ok": 46
  },
  "/elestodao.elesto.did.MsgCreateDidDocument": {
   "failure": 49,
   "ok": 264
  },
  "/elestodao.elesto.did.MsgDeleteService": {
   "failure": 293,
   "ok": 2
  },
  "/elestodao.elesto.did.MsgRevokeVerification": {
   "failure": 322,
   "ok": 4
  },
  "/elestodao.elesto.did.MsgSetVerificationRelationships": {
   "failure": 607,
   "ok": 17
  }
 },
```