### PR TITLE
feat(test): add tests to keeper.go and did.go in keeper package

### DIFF
--- a/x/did/client/cli/cli_test.go
+++ b/x/did/client/cli/cli_test.go
@@ -80,8 +80,7 @@ func name(others ...string) string {
 	return fmt.Sprintln(f.Name(), others)
 }
 
-func addnewdiddoc(s *IntegrationTestSuite, identifier string, val *network.Validator) {
-
+func addNewDidDoc(s *IntegrationTestSuite, identifier string, val *network.Validator) {
 	clientCtx := val.ClientCtx
 	args := []string{
 		identifier,
@@ -128,7 +127,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryDidDocument() {
 			name() + "_2",
 			codes.OK,
 			&did.QueryDidDocumentResponse{},
-			func() { addnewdiddoc(s, identifier, val) },
+			func() { addNewDidDoc(s, identifier, val) },
 		},
 	}
 
@@ -158,7 +157,6 @@ func (s *IntegrationTestSuite) TestGetCmdQueryDidDocument() {
 }
 
 func (s *IntegrationTestSuite) TestNewCreateDidDocumentCmd() {
-
 	identifier := "123456789abcdefghijkc"
 	val := s.network.Validators[0]
 	clientCtx := val.ClientCtx
@@ -244,7 +242,7 @@ func (s *IntegrationTestSuite) TestNewAddControllerCmd() {
 				),
 			},
 			&sdk.TxResponse{},
-			func() { addnewdiddoc(s, identifier1, val) },
+			func() { addNewDidDoc(s, identifier1, val) },
 		},
 	}
 
@@ -307,7 +305,7 @@ func (s *IntegrationTestSuite) TestNewDeleteControllerCmd() {
 			&sdk.TxResponse{},
 			func() {
 				// create a new did document
-				addnewdiddoc(s, identifier1, val)
+				addNewDidDoc(s, identifier1, val)
 				// add a controller parameters
 				args := []string{
 					identifier1,
@@ -393,7 +391,7 @@ func (s *IntegrationTestSuite) TestNewAddVerificationCmd() {
 			},
 			codes.OK,
 			&sdk.TxResponse{},
-			func() { addnewdiddoc(s, identifier, val) },
+			func() { addNewDidDoc(s, identifier, val) },
 		},
 	}
 
@@ -464,7 +462,7 @@ func (s *IntegrationTestSuite) TestNewSetVerificationRelationshipsCmd() {
 			},
 			codes.OK,
 			&sdk.TxResponse{},
-			func() { addnewdiddoc(s, identifier, val) },
+			func() { addNewDidDoc(s, identifier, val) },
 		},
 	}
 
@@ -537,7 +535,7 @@ func (s *IntegrationTestSuite) TestNewRevokeVerificationCmd() {
 			},
 			codes.OK,
 			&sdk.TxResponse{},
-			func() { addnewdiddoc(s, identifier, val) },
+			func() { addNewDidDoc(s, identifier, val) },
 		},
 	}
 
@@ -611,7 +609,7 @@ func (s *IntegrationTestSuite) TestNewAddServiceCmd() {
 			},
 			codes.OK,
 			&sdk.TxResponse{},
-			func() { addnewdiddoc(s, identifier, val) },
+			func() { addNewDidDoc(s, identifier, val) },
 		},
 	}
 
@@ -675,7 +673,7 @@ func (s *IntegrationTestSuite) TestNewDeleteServiceCmd() {
 			name(),
 			&sdk.TxResponse{},
 			func() {
-				addnewdiddoc(s, identifier, val)
+				addNewDidDoc(s, identifier, val)
 				cmd := cli.NewAddServiceCmd()
 				out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, args)
 				s.Require().NoError(err)

--- a/x/did/keeper/did.go
+++ b/x/did/keeper/did.go
@@ -24,11 +24,11 @@ func (k Keeper) GetDidDocument(ctx sdk.Context, key []byte) (did.DidDocument, bo
 // HasDidDocument checks if a DID document is in the store  by its key.
 // The boolean return will be false if the DID document is not found
 func (k Keeper) HasDidDocument(ctx sdk.Context, key []byte) bool {
-	found := k.Has(ctx, key, did.DidDocumentKey, k.UnmarshalDidDocument)
+	found := k.Has(ctx, key, did.DidDocumentKey)
 	return found
 }
 
-// UnmarshalDidDocument unmarshall a did document= and check if it is empty
+// UnmarshalDidDocument unmarshall a did document and check if it is empty
 // ad DID document is empty if contains no context
 func (k Keeper) UnmarshalDidDocument(value []byte) (interface{}, bool) {
 	data := did.DidDocument{}

--- a/x/did/keeper/did_test.go
+++ b/x/did/keeper/did_test.go
@@ -2,45 +2,112 @@ package keeper
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/elesto-dao/elesto/x/did"
 )
 
-func (suite *KeeperTestSuite) TestDidDocumentKeeperSetAndGet() {
+func (suite *KeeperTestSuite) TestDidDocumentKeeper() {
 	testCases := []struct {
 		msg     string
 		didFn   func() did.DidDocument
 		expPass bool
 	}{
 		{
-			"data stored successfully",
+			"PASS: did document stored successfully",
 			func() did.DidDocument {
 				dd, _ := did.NewDidDocument("did:cosmos:net:elesto:subject")
+				suite.keeper.SetDidDocument(suite.ctx, []byte(dd.Id), dd)
 				return dd
 			},
 			true,
+		},
+		{
+			"FAIL: did document does not exist",
+			func() did.DidDocument {
+				dd, _ := did.NewDidDocument("did:cosmos:net:elesto:not")
+				return dd
+			},
+			false,
 		},
 	}
 	for _, tc := range testCases {
 		dd := tc.didFn()
 
-		suite.keeper.SetDidDocument(suite.ctx, []byte(dd.Id), dd)
-		suite.keeper.SetDidDocument(suite.ctx, []byte(dd.Id+"1"), dd)
 		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
 			if tc.expPass {
-				_, found := suite.keeper.GetDidDocument(
+				found := suite.keeper.HasDidDocument(
 					suite.ctx,
 					[]byte(dd.Id),
 				)
 				suite.Require().True(found)
 
+				ddGet, found := suite.keeper.GetDidDocument(
+					suite.ctx,
+					[]byte(dd.Id),
+				)
+				suite.Require().Equal(dd, ddGet)
+
 				allEntities := suite.keeper.GetAllDidDocuments(
 					suite.ctx,
 				)
-				suite.Require().Equal(2, len(allEntities))
+				suite.Require().Equal(1, len(allEntities))
 			} else {
-				// TODO write failure cases
-				suite.Require().False(tc.expPass)
+				found := suite.keeper.HasDidDocument(
+					suite.ctx,
+					[]byte(dd.Id),
+				)
+				suite.Require().False(found)
+			}
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestDidDocumentMetadataKeeper() {
+	testCases := []struct {
+		msg     string
+		didFn   func() (did.DidMetadata, did.DidDocument)
+		expPass bool
+	}{
+		{
+			"PASS: did document metadata stored successfully",
+			func() (did.DidMetadata, did.DidDocument) {
+				dd, _ := did.NewDidDocument("did:cosmos:net:elesto:subject")
+				didMeta := did.NewDidMetadata([]byte("xxx"), time.Now())
+				suite.keeper.SetDidDocument(suite.ctx, []byte(dd.Id), dd)
+				suite.keeper.SetDidMetadata(suite.ctx, []byte(dd.Id), didMeta)
+				return didMeta, dd
+			},
+			true,
+		},
+		{
+			"FAIL: did document does not exist",
+			func() (did.DidMetadata, did.DidDocument) {
+				dd, _ := did.NewDidDocument("did:cosmos:net:elesto:fail")
+				didMeta := did.NewDidMetadata([]byte("xxx"), time.Now().Local())
+				suite.keeper.SetDidMetadata(suite.ctx, []byte(dd.Id), didMeta)
+				return didMeta, dd
+			},
+			false,
+		},
+	}
+	for _, tc := range testCases {
+		didMeta, dd := tc.didFn()
+
+		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
+			if tc.expPass {
+				didMetaGet, found := suite.keeper.GetDidMetadata(
+					suite.ctx,
+					[]byte(dd.Id),
+				)
+				suite.Require().True(found)
+				suite.Require().Equal(didMeta.VersionId, didMetaGet.VersionId)
+			} else {
+				_, _, err := suite.keeper.ResolveDid(
+					suite.ctx,
+					did.NewChainDID("elesto", "fail"),
+				)
+				suite.Require().Error(err)
 			}
 		})
 	}

--- a/x/did/keeper/keeper.go
+++ b/x/did/keeper/keeper.go
@@ -76,7 +76,6 @@ func (k Keeper) Has(
 	ctx sdk.Context,
 	key []byte,
 	prefix []byte,
-	unmarshal UnmarshalFn,
 ) (found bool) {
 	store := ctx.KVStore(k.storeKey)
 	return store.Has(append(prefix, key...))


### PR DESCRIPTION
### Description

- updated tests in keeper package

### How to test

- `make test`

### Output

```
ok  	github.com/elesto-dao/elesto/x/did	(cached)	coverage: 9.7% of statements
ok  	github.com/elesto-dao/elesto/x/did/client/cli	(cached)	coverage: 60.0% of statements
ok  	github.com/elesto-dao/elesto/x/did/keeper	0.455s	coverage: 96.2% of statements
ok  	github.com/elesto-dao/elesto/x/did/module	(cached)	coverage: 52.0% of statements
ok  	github.com/elesto-dao/elesto/x/did/simulation	(cached)	coverage: 84.8% of statements
```