### PR TITLE
chore: update golang-ci config for go1.18

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.44.0
+  rev: v1.45.2
   hooks:
     - id: golangci-lint
 # commit msg check


### PR DESCRIPTION
pre-commit hooks setup uses a version of golangci that does not support golang v1.18,
this PR upgrades the version of golangci-lint to v1.45.2