### PR TITLE
chore: updating Makefile to specify ignite binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ docs:
 	mkdocs serve
 
 openapi:
-	starport generate openapi
+	ignite generate openapi
 
 .PHONY: docs openapi
 


### PR DESCRIPTION
change from "starport generate openapi" to "ignite generate openapi"