### PR TITLE
test: increase test coverage for model critical section (>80%)

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - name: Run coverage
         run: make test-ci
       - name: Upload coverage to Codecov

--- a/x/credential/client/cli/credential.go
+++ b/x/credential/client/cli/credential.go
@@ -203,10 +203,16 @@ func NewMakeCredentialFromSchemaCmd() *cobra.Command {
 			id, _ := wc.GetSubjectID()
 			id = strings.TrimPrefix(id, "did:cosmos:elesto:")
 			outFile := strings.ToLower(fmt.Sprintf("credential.%s.%s.json", schema.Title, id))
-			if n := q("leave it empty not to save", "credential filename", outFile); !credential.IsEmpty(n) {
-				return os.WriteFile(n, wc.GetBytes(), 0600)
+
+			wcB, err := wc.GetBytes()
+			if err != nil {
+				return err
 			}
-			return clientCtx.PrintBytes(wc.GetBytes())
+
+			if n := q("leave it empty not to save", "credential filename", outFile); !credential.IsEmpty(n) {
+				return os.WriteFile(n, wcB, 0600)
+			}
+			return clientCtx.PrintBytes(wcB)
 		},
 	}
 

--- a/x/credential/client/cli/query.go
+++ b/x/credential/client/cli/query.go
@@ -152,7 +152,12 @@ func NewQueryPublicCredentialCmd() *cobra.Command {
 			if printNative {
 				return clientCtx.PrintProto(wc.PublicVerifiableCredential)
 			}
-			return clientCtx.PrintBytes(wc.GetBytes())
+			wcB, err := wc.GetBytes()
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintBytes(wcB)
 		},
 	}
 	cmd.Flags().BoolVar(&printNative, "native", false, "if set the credential will be printed in the raw format, that is how it is stored on chain")

--- a/x/credential/errors.go
+++ b/x/credential/errors.go
@@ -15,7 +15,6 @@ var (
 
 	ErrVerifiableCredentialNotFound = sdkerrors.Register(ModuleName, 2102, "vc not found")
 	ErrVerifiableCredentialFound    = sdkerrors.Register(ModuleName, 2103, "vc found")
-	ErrDidDocumentDoesNotExist      = sdkerrors.Register(ModuleName, 2104, "did does not exist in the store")
 	ErrVerifiableCredentialIssuer   = sdkerrors.Register(ModuleName, 2105, "provided verifiable credential and did public key do not match")
 	ErrInvalidProof                 = sdkerrors.Register(ModuleName, 2106, "credential proof validation error")
 	ErrCredentialNotIssuable        = sdkerrors.Register(ModuleName, 2107, "credential cannot be issued on-chain")

--- a/x/credential/keeper/msg_server.go
+++ b/x/credential/keeper/msg_server.go
@@ -158,7 +158,13 @@ func (k msgServer) IssuePublicVerifiableCredential(
 		k.Logger(ctx).Error(err.Error())
 		return nil, err
 	}
-	crL := gojsonschema.NewBytesLoader(wc.GetBytes())
+	wcB, err := wc.GetBytes()
+	if err != nil {
+		err = sdkerrors.Wrapf(credential.ErrInvalidCredential, "the credential %s is corrupted: %v", wc.Id, err)
+		k.Logger(ctx).Error(err.Error())
+		return nil, err
+	}
+	crL := gojsonschema.NewBytesLoader(wcB)
 	dataValidator, err := schema.Validate(crL)
 	if err != nil {
 		err = sdkerrors.Wrapf(credential.ErrInvalidCredential, "the credential doesn't match the schema: %v", msg.CredentialDefinitionID)


### PR DESCRIPTION
```
➜ go test -tags test -coverprofile=/tmp/c.out . && grep -v .pb. /tmp/c.out > /tmp/coverage.out && go tool cover -html=/tmp/coverage.out -o=/tmp/coverage.html && goverreport -coverprofile=/tmp/coverage.out -sort stmt
ok  	github.com/elesto-dao/elesto/x/credential	0.031s	coverage: 2.6% of statements
+-------------------------------------------------------------+--------+---------+-------+---------+---------------+--------------+
|                            File                             | Blocks | Missing | Stmts | Missing | Block cover % | Stmt cover % |
+-------------------------------------------------------------+--------+---------+-------+---------+---------------+--------------+
| github.com/elesto-dao/elesto/x/credential/codec.go          |      2 |       2 |     2 |       2 |          0.00 |         0.00 |
| github.com/elesto-dao/elesto/x/credential/event.go          |      3 |       3 |     3 |       3 |          0.00 |         0.00 |
| github.com/elesto-dao/elesto/x/credential/msg.go            |     21 |      21 |    27 |      27 |          0.00 |         0.00 |
| github.com/elesto-dao/elesto/x/credential/credential.go     |     54 |       9 |    73 |       9 |         83.33 |        87.67 | <
| github.com/elesto-dao/elesto/x/credential/helpers.go        |      6 |       0 |     9 |       0 |        100.00 |       100.00 | <
| github.com/elesto-dao/elesto/x/credential/msg_validation.go |     21 |       0 |    21 |       0 |        100.00 |       100.00 | <
+-------------------------------------------------------------+--------+---------+-------+---------+---------------+--------------+
|                                                       Total |    107 |      35 |   135 |      41 |         67.29 |        69.63 |
+-------------------------------------------------------------+--------+---------+-------+---------+---------------+--------------+

```