### PR TITLE
feat: add k3d local devnet scripts

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - k3d-devnet
 
 jobs:
   release:

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -1,0 +1,53 @@
+name: Release Container
+on: 
+  push:
+    branches:
+      - main
+      - k3d-devnet
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Image metadata
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: type=raw,value={{date 'YY.DDD-X'}}-{{sha}}
+      - name: Build and push elestod
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          context: ./
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Init Image metadata
+        uses: docker/metadata-action@v4
+        id: init-meta
+        with:
+          images: ghcr.io/${{ github.repository }}-init
+          tags: type=raw,value={{date 'YY.DDD-X'}}-{{sha}}
+      - name: Build and push elestod-init
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          context: ./scripts/devnet/kubernetes/0-init/
+          tags: ${{ steps.init-meta.outputs.tags }}
+          labels: ${{ steps.init-meta.outputs.labels }}
+          build-args: ELESTOD_IMAGE_TAG=ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /workspace
 COPY . .
 RUN LEDGER_ENABLED=false make build
 
-FROM scratch
+FROM ghcr.io/glebiller/tendermint-readiness:0.1.0
 COPY --from=build /workspace/build/elestod /elestod
 
 ENTRYPOINT ["/elestod"]

--- a/scripts/devnet/kubernetes/.gitignore
+++ b/scripts/devnet/kubernetes/.gitignore
@@ -1,0 +1,1 @@
+registries.yaml

--- a/scripts/devnet/kubernetes/0-init/Dockerfile
+++ b/scripts/devnet/kubernetes/0-init/Dockerfile
@@ -1,0 +1,7 @@
+FROM rancher/kubectl:v1.23.7 AS kubectl
+FROM us-central1-docker.pkg.dev/elesto/elesto/elestod:2.0.0-rc2-readiness AS elestod
+FROM bash:latest
+COPY --from=kubectl /bin/kubectl /usr/local/bin/kubectl
+COPY --from=elestod /elestod /usr/local/bin/elestod
+RUN wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x /usr/local/bin/jq
+COPY *.sh /usr/local/bin/

--- a/scripts/devnet/kubernetes/0-init/Dockerfile
+++ b/scripts/devnet/kubernetes/0-init/Dockerfile
@@ -1,5 +1,5 @@
-FROM rancher/kubectl:v1.23.7 AS kubectl
 FROM us-central1-docker.pkg.dev/elesto/elesto/elestod:2.0.0-rc2-readiness AS elestod
+FROM rancher/kubectl:v1.23.7 AS kubectl
 FROM bash:latest
 COPY --from=kubectl /bin/kubectl /usr/local/bin/kubectl
 COPY --from=elestod /elestod /usr/local/bin/elestod

--- a/scripts/devnet/kubernetes/0-init/Dockerfile
+++ b/scripts/devnet/kubernetes/0-init/Dockerfile
@@ -1,4 +1,5 @@
-FROM us-central1-docker.pkg.dev/elesto/elesto/elestod:2.0.0-rc2-readiness AS elestod
+ARG ELESTOD_IMAGE_TAG
+FROM $ELESTOD_IMAGE_TAG AS elestod
 FROM rancher/kubectl:v1.23.7 AS kubectl
 FROM bash:latest
 COPY --from=kubectl /bin/kubectl /usr/local/bin/kubectl

--- a/scripts/devnet/kubernetes/0-init/init-genesis.sh
+++ b/scripts/devnet/kubernetes/0-init/init-genesis.sh
@@ -1,0 +1,54 @@
+#!/usr/local/bin/bash
+
+GENESIS_AMOUNT=${GENESIS_AMOUNT:-100000000}
+
+# Init node
+if [[ ! -f /home/config/node_key.json ]]; then
+  echo "Init ${MONIKER} on ${CHAIN_ID}"
+  elestod init ${MONIKER} --home=/home/ --chain-id=${CHAIN_ID}
+  sed -i 's|keyring-backend = ".*"|keyring-backend = "test"|' /home/config/client.toml
+fi
+
+# Create key if it does not exists
+if [ "$(elestod keys list --output json --home /home/ | jq -r --arg MONIKER "${MONIKER}" '.[] | select(.name == $MONIKER).name')" != "${MONIKER}" ]; then
+  echo "Create ${MONIKER} key"
+  elestod keys add ${MONIKER} --home=/home/ --output json | jq -r '.mnemonic' > /home/config/${MONIKER}_mnemonic
+  elestod add-genesis-account $(elestod keys show ${MONIKER} --home=/home/ -a) ${GENESIS_AMOUNT}stake --home=/home/
+fi
+
+# Create regulator
+if [ "$(elestod keys list --output json --home /home/ | jq -r '.[] | select(.name == "regulator").name')" != "regulator" ]; then
+  echo "Create regulator key"
+  echo ${REGULATOR_KEY} | elestod keys add regulator --home=/home/ --output json --recover
+  elestod add-genesis-account $(elestod keys show regulator --home=/home/ -a) 20000000stake --home=/home/
+fi
+
+# Create emti (e-money token issuer)
+if [ "$(elestod keys list --output json --home /home/ | jq -r '.[] | select(.name == "emti").name')" != "emti" ]; then
+  echo "Create emti key"
+  echo ${EMTI_KEY} | elestod keys add emti --home=/home/ --output json --recover
+  elestod add-genesis-account $(elestod keys show emti --home=/home/ -a) 20000000stake --home=/home/
+fi
+
+# Create arti (asset-referenced token issuer)
+if [ "$(elestod keys list --output json --home /home/ | jq -r '.[] | select(.name == "arti").name')" != "arti" ]; then
+  echo "Create arti key"
+  echo ${ARTI_KEY} | elestod keys add arti --home=/home/ --output json --recover
+  elestod add-genesis-account $(elestod keys show arti --home=/home/ -a) 20000000stake --home=/home/
+fi
+
+if [ "$(jq -r '.app_state.genutil.gen_txs | length' /home/config/genesis.json)" == "0" ]; then
+  # Generate a transaction & save it to the Genesis file
+  echo "Generate transaction and collect to Genesis on chain ${CHAIN_ID}"
+  elestod gentx ${MONIKER} 70000000stake --home=/home/ --chain-id=${CHAIN_ID}
+  elestod collect-gentxs --home=/home/
+fi
+
+# Update Genesis
+jq '.app_state["staking"]["params"]["unbonding_time"] = "240s"' /home/config/genesis.json > /home/config/genesis.json.tmp  && mv /home/config/genesis.json.tmp /home/config/genesis.json
+jq '.app_state["gov"]["voting_params"]["voting_period"] = "60s"' /home/config/genesis.json > /home/config/genesis.json.tmp  && mv /home/config/genesis.json.tmp /home/config/genesis.json
+
+# Create/Update genesis configmap
+echo "Update configmap and secret"
+kubectl create configmap ${MONIKER%-*} --dry-run=client --output=yaml --from-file /home/config/genesis.json | kubectl apply --force=true --filename=-
+kubectl create secret generic ${MONIKER} --dry-run=client --output=yaml --from-file MNEMONIC=/home/config/${MONIKER}_mnemonic | kubectl apply --force=true --filename=-

--- a/scripts/devnet/kubernetes/0-init/init-genesis.sh
+++ b/scripts/devnet/kubernetes/0-init/init-genesis.sh
@@ -16,21 +16,21 @@ if [ "$(elestod keys list --output json --home /home/ | jq -r --arg MONIKER "${M
   elestod add-genesis-account $(elestod keys show ${MONIKER} --home=/home/ -a) ${GENESIS_AMOUNT}stake --home=/home/
 fi
 
-# Create regulator
+# Create regulator key
 if [ "$(elestod keys list --output json --home /home/ | jq -r '.[] | select(.name == "regulator").name')" != "regulator" ]; then
   echo "Create regulator key"
   echo ${REGULATOR_KEY} | elestod keys add regulator --home=/home/ --output json --recover
   elestod add-genesis-account $(elestod keys show regulator --home=/home/ -a) 20000000stake --home=/home/
 fi
 
-# Create emti (e-money token issuer)
+# Create e-money token issuer (EMTI) key
 if [ "$(elestod keys list --output json --home /home/ | jq -r '.[] | select(.name == "emti").name')" != "emti" ]; then
   echo "Create emti key"
   echo ${EMTI_KEY} | elestod keys add emti --home=/home/ --output json --recover
   elestod add-genesis-account $(elestod keys show emti --home=/home/ -a) 20000000stake --home=/home/
 fi
 
-# Create arti (asset-referenced token issuer)
+# Create asset-referenced issuer (ARTI) token
 if [ "$(elestod keys list --output json --home /home/ | jq -r '.[] | select(.name == "arti").name')" != "arti" ]; then
   echo "Create arti key"
   echo ${ARTI_KEY} | elestod keys add arti --home=/home/ --output json --recover
@@ -48,7 +48,7 @@ fi
 jq '.app_state["staking"]["params"]["unbonding_time"] = "240s"' /home/config/genesis.json > /home/config/genesis.json.tmp  && mv /home/config/genesis.json.tmp /home/config/genesis.json
 jq '.app_state["gov"]["voting_params"]["voting_period"] = "60s"' /home/config/genesis.json > /home/config/genesis.json.tmp  && mv /home/config/genesis.json.tmp /home/config/genesis.json
 
-# Create/Update genesis configmap
+# Create or update genesis configmap
 echo "Update configmap and secret"
 kubectl create configmap ${MONIKER%-*} --dry-run=client --output=yaml --from-file /home/config/genesis.json | kubectl apply --force=true --filename=-
 kubectl create secret generic ${MONIKER} --dry-run=client --output=yaml --from-file MNEMONIC=/home/config/${MONIKER}_mnemonic | kubectl apply --force=true --filename=-

--- a/scripts/devnet/kubernetes/0-init/init-seed.sh
+++ b/scripts/devnet/kubernetes/0-init/init-seed.sh
@@ -1,0 +1,21 @@
+#!/usr/local/bin/bash
+
+INIT_FROM=${INIT_FROM:-'genesis-0'}
+
+#Wait for pods
+kubectl wait pod -l app.kubernetes.io/name=genesis --for condition=Ready
+
+# Init node
+if [[ ! -f /home/config/node_key.json ]]; then
+  echo "Init ${MONIKER} on ${CHAIN_ID}"
+  elestod init ${MONIKER} --home=/home/ --chain-id=${CHAIN_ID}
+  sed -i 's|keyring-backend = ".*"|keyring-backend = "test"|' /home/config/client.toml
+fi
+
+# Update configmap & secret
+echo "Update configmap and secret"
+INIT_FROM_ID=$(wget -O - -o /dev/null http://${INIT_FROM%-*}:26657/status | jq -r '.result.node_info.id' | tr -d '\n')
+cat /dev/null > /home/config/seeds-env
+echo "P2P_PERSISTENT_PEERS=${INIT_FROM_ID}@${INIT_FROM%-*}:26656" >> /home/config/seeds-env
+echo "P2P_PRIVATE_PEER_IDS=${INIT_FROM_ID}" >> /home/config/seeds-env
+kubectl create configmap ${MONIKER%-*}s-env --dry-run=client --output=yaml --from-env-file=/home/config/seeds-env | kubectl apply --force=true --filename=-

--- a/scripts/devnet/kubernetes/0-init/init-validator.sh
+++ b/scripts/devnet/kubernetes/0-init/init-validator.sh
@@ -22,7 +22,7 @@ if [ "$(elestod keys list --output json --home /home/ | jq -r --arg INIT_FROM "$
   kubectl get secret ${INIT_FROM} --output json | jq -r '.data.MNEMONIC' | base64 -d | elestod keys add ${INIT_FROM} --home=/home/ --output json --recover
 fi
 
-# Create key if it does not exists
+# Create a key if it doesn't exist
 if [ "$(elestod keys list --output json --home /home/ | jq -r --arg MONIKER "${MONIKER}" '.[] | select(.name == $MONIKER).name')" != "${MONIKER}" ]; then
   echo "Create ${MONIKER} key"
   elestod keys add ${MONIKER} --home=/home/ --output json | jq -r '.mnemonic' > /home/config/${MONIKER}_mnemonic
@@ -43,7 +43,7 @@ if [ "$(elestod query bank balances ${TO_ADDRESS} --home=/home/ --chain-id=${CHA
   done
 fi
 
-# Create validator
+# Create the validator
 VALIDATOR_PUBKEY=$(elestod tendermint show-validator --home=/home/)
 if [ "$(elestod query staking validators --home=/home/ --chain-id=${CHAIN_ID} --limit 100 --node tcp://${INIT_FROM%-*}:26657 --output json | jq -r --argjson PUBKEY "${VALIDATOR_PUBKEY}" '.validators[] | select(.consensus_pubkey==$PUBKEY).tokens')" != "${AMOUNT}" ]; then
   echo "Create validator with ${AMOUNT}stake from${MONIKER} at address ${FROM_ADDRESS} with pubkey ${VALIDATOR_PUBKEY}"

--- a/scripts/devnet/kubernetes/0-init/init-validator.sh
+++ b/scripts/devnet/kubernetes/0-init/init-validator.sh
@@ -1,0 +1,68 @@
+#!/usr/local/bin/bash
+
+# TODO param
+AMOUNT=${AMOUNT:-10000000} # Maybe check it's below minimum amount?
+INIT_FROM=${INIT_FROM:-'genesis-0'}
+SEED_FROM=${SEED_FROM:-'seed-0'}
+
+# Wait for pods
+kubectl wait pod -l app.kubernetes.io/name=genesis --for condition=Ready
+kubectl wait pod -l app.kubernetes.io/name=seed --for condition=Ready
+
+# Init node
+if [[ ! -f /home/config/node_key.json ]]; then
+  echo "Init ${MONIKER} on ${CHAIN_ID}"
+  elestod init ${MONIKER} --home=/home/ --chain-id=${CHAIN_ID}
+  sed -i 's|keyring-backend = ".*"|keyring-backend = "test"|' /home/config/client.toml
+fi
+
+# Add ${INIT_FROM} private key
+if [ "$(elestod keys list --output json --home /home/ | jq -r --arg INIT_FROM "${INIT_FROM}" '.[] | select(.name == $INIT_FROM).name')" != "${INIT_FROM}" ]; then
+  echo "Add ${INIT_FROM} key"
+  kubectl get secret ${INIT_FROM} --output json | jq -r '.data.MNEMONIC' | base64 -d | elestod keys add ${INIT_FROM} --home=/home/ --output json --recover
+fi
+
+# Create key if it does not exists
+if [ "$(elestod keys list --output json --home /home/ | jq -r --arg MONIKER "${MONIKER}" '.[] | select(.name == $MONIKER).name')" != "${MONIKER}" ]; then
+  echo "Create ${MONIKER} key"
+  elestod keys add ${MONIKER} --home=/home/ --output json | jq -r '.mnemonic' > /home/config/${MONIKER}_mnemonic
+fi
+
+FROM_ADDRESS=$(elestod keys show ${INIT_FROM} --home=/home/ --address)
+TO_ADDRESS=$(elestod keys show ${MONIKER} --home=/home/ --address)
+
+# Send token from ${INIT_FROM} to ${MONIKER}
+if [ "$(elestod query bank balances ${TO_ADDRESS} --home=/home/ --chain-id=${CHAIN_ID} --node tcp://${INIT_FROM%-*}:26657 --output json | jq -r '.balances[] | select(.denom="stake").amount')" != "${AMOUNT}" ]; then
+  echo "Send ${AMOUNT}stake from ${INIT_FROM} at address ${FROM_ADDRESS} to ${MONIKER} at address ${TO_ADDRESS}"
+  elestod tx bank send ${FROM_ADDRESS} ${TO_ADDRESS} ${AMOUNT}stake --home=/home/ --chain-id=${CHAIN_ID} --from ${FROM_ADDRESS} --node tcp://${INIT_FROM%-*}:26657 --output json --yes
+
+  # Wait for transaction to complete & check
+  while [ "$(elestod query bank balances ${TO_ADDRESS} --home=/home/ --chain-id=${CHAIN_ID} --node tcp://${INIT_FROM%-*}:26657 --output json | jq -r '.balances[] | select(.denom="stake").amount')" != "${AMOUNT}" ]; do
+    echo "tx bank send transaction still not processed (amount not found)"
+    sleep 1;
+  done
+fi
+
+# Create validator
+VALIDATOR_PUBKEY=$(elestod tendermint show-validator --home=/home/)
+if [ "$(elestod query staking validators --home=/home/ --chain-id=${CHAIN_ID} --limit 100 --node tcp://${INIT_FROM%-*}:26657 --output json | jq -r --argjson PUBKEY "${VALIDATOR_PUBKEY}" '.validators[] | select(.consensus_pubkey==$PUBKEY).tokens')" != "${AMOUNT}" ]; then
+  echo "Create validator with ${AMOUNT}stake from${MONIKER} at address ${FROM_ADDRESS} with pubkey ${VALIDATOR_PUBKEY}"
+  elestod tx staking create-validator --home=/home/ --amount=${AMOUNT}stake --from=${MONIKER} --pubkey=${VALIDATOR_PUBKEY} --moniker=${MONIKER} --chain-id=${CHAIN_ID} --commission-rate="0.1" --commission-max-rate="0.2" --commission-max-change-rate="0.05" --min-self-delegation="${AMOUNT}" --node tcp://${INIT_FROM%-*}:26657 --output json --yes
+
+  # Wait for transaction to complete & check
+  while [ "$(elestod query staking validators --home=/home/ --chain-id=${CHAIN_ID} --limit 100 --node tcp://${INIT_FROM%-*}:26657 --output json | jq -r --argjson PUBKEY "${VALIDATOR_PUBKEY}" '.validators[] | select(.consensus_pubkey==$PUBKEY).tokens')" != "${AMOUNT}" ]; do
+    echo "staking create-validator transaction still not processed (bonded amount not found)"
+    sleep 1;
+  done
+fi
+
+# Update configmap & secret
+echo "Update configmap and secret"
+INIT_FROM_ID=$(wget -O - -o /dev/null http://${INIT_FROM%-*}:26657/status | jq -r '.result.node_info.id' | tr -d '\n')
+SEED_FROM_ID=$(wget -O - -o /dev/null http://${SEED_FROM%-*}:26657/status | jq -r '.result.node_info.id' | tr -d '\n')
+cat /dev/null > /home/config/validators-env
+echo "P2P_PERSISTENT_PEERS=${INIT_FROM_ID}@${INIT_FROM%-*}:26656" >> /home/config/validators-env
+echo "P2P_PRIVATE_PEER_IDS=${INIT_FROM_ID}" >> /home/config/validators-env
+echo "P2P_SEEDS=${SEED_FROM_ID}@${SEED_FROM%-*}:26656" >> /home/config/validators-env
+kubectl create configmap ${MONIKER%-*}s-env --dry-run=client --output=yaml --from-env-file=/home/config/validators-env | kubectl apply --force=true --filename=-
+kubectl create secret generic ${MONIKER} --dry-run=client --output=yaml --from-file MNEMONIC=/home/config/${MONIKER}_mnemonic | kubectl apply --force=true --filename=-

--- a/scripts/devnet/kubernetes/1-common/kustomization.yaml
+++ b/scripts/devnet/kubernetes/1-common/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - rbac.yaml

--- a/scripts/devnet/kubernetes/1-common/namespace.yaml
+++ b/scripts/devnet/kubernetes/1-common/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local

--- a/scripts/devnet/kubernetes/1-common/rbac.yaml
+++ b/scripts/devnet/kubernetes/1-common/rbac.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: blockchain-node
+  namespace: local
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: blockchain-node
+  namespace: local
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ "list", "get", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "configmaps", "secrets" ]
+    verbs: [ "get", "create", "update", "patch" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: blockchain-node
+  namespace: local
+subjects:
+  - kind: ServiceAccount
+    name: blockchain-node
+roleRef:
+  kind: Role
+  name: blockchain-node
+  apiGroup: rbac.authorization.k8s.io

--- a/scripts/devnet/kubernetes/2-genesis/kustomization.yaml
+++ b/scripts/devnet/kubernetes/2-genesis/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: local
+resources:
+  - service.yaml
+  - statefulset.yaml
+secretGenerator:
+  - name: genesis-accounts
+    literals:
+      - REGULATOR_KEY=exotic confirm wealth punch muscle release theme region sadness gas whip unhappy social voice canyon edit also unknown together aim dumb math dolphin cry
+      - EMTI_KEY=cook fuel gadget already laptop impose ski parrot rotate van space stuff scan immune dry announce fun spin few book beyond check melt rely
+      - ARTI_KEY=excess fold traffic elbow spray depth festival sniff gain arrange symbol barrel betray damp merit hungry observe excite notice deliver volcano confirm book photo

--- a/scripts/devnet/kubernetes/2-genesis/service.yaml
+++ b/scripts/devnet/kubernetes/2-genesis/service.yaml
@@ -1,0 +1,30 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: genesis
+  namespace: local
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: genesis
+    app.kubernetes.io/component: node
+    app.kubernetes.io/part-of: elesto
+  ports:
+    - port: 1317
+      name: api
+      targetPort: api
+    - port: 9090
+      name: grpc
+      targetPort: grpc
+    - port: 26656
+      name: p2p
+      targetPort: p2p
+    - port: 26657
+      name: rpc
+      targetPort: rpc
+    - port: 26660
+      name: telemetry
+      targetPort: telemetry
+

--- a/scripts/devnet/kubernetes/2-genesis/statefulset.yaml
+++ b/scripts/devnet/kubernetes/2-genesis/statefulset.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       initContainers:
         - name: init-blockchain
-          image: elestod-init:local
+          image: ghcr.io/elesto-dao/elesto-init:22.217-1659728311-910d4da
           command:
             - init-genesis.sh
           env:
@@ -49,7 +49,7 @@ spec:
               mountPath: /home/
       containers:
         - name: application
-          image: us-central1-docker.pkg.dev/elesto/elesto/elestod:2.0.0-rc2-snapshots
+          image: ghcr.io/elesto-dao/elesto:22.217-1659728311-910d4da
           args: [
             "start",
             "--db_backend", "goleveldb",

--- a/scripts/devnet/kubernetes/2-genesis/statefulset.yaml
+++ b/scripts/devnet/kubernetes/2-genesis/statefulset.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: genesis
+  namespace: local
+  labels:
+    app.kubernetes.io/name: genesis
+    app.kubernetes.io/component: node
+    app.kubernetes.io/part-of: elesto
+spec:
+  replicas: 1
+  serviceName: genesis
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: genesis
+      app.kubernetes.io/component: node
+      app.kubernetes.io/part-of: elesto
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: genesis
+        app.kubernetes.io/component: node
+        app.kubernetes.io/part-of: elesto
+    spec:
+      initContainers:
+        - name: init-blockchain
+          image: elestod-init:local
+          command:
+            - init-genesis.sh
+          env:
+            - name: CHAIN_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MONIKER
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          envFrom:
+            - secretRef:
+                name: genesis-accounts
+          #securityContext: # TODO not working
+          #  runAsUser: 20000
+          #  runAsGroup: 20000
+          #  runAsNonRoot: true
+          volumeMounts:
+            - name: node-home
+              mountPath: /home/
+      containers:
+        - name: application
+          image: us-central1-docker.pkg.dev/elesto/elesto/elestod:2.0.0-rc2-snapshots
+          args: [
+            "start",
+            "--db_backend", "goleveldb",
+            "--grpc.enable", "true",
+            "--grpc-web.enable", "false",
+            "--moniker", "$(MONIKER)",
+            "--home", "/home/",
+            "--log_level", "info",
+            "--pruning", "default",
+            "--rpc.laddr", "tcp://0.0.0.0:26657",
+            "--state-sync.snapshot-interval", "100",
+            "--state-sync.snapshot-keep-recent", "2"
+          ]
+          env:
+            - name: MONIKER
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          resources: { }
+          ports:
+            - name: api
+              containerPort: 1317
+            - name: grpc
+              containerPort: 9090
+            - name: grpc-web
+              containerPort: 9091
+            - name: abci
+              containerPort: 26658
+            - name: rpc
+              containerPort: 26657
+            - name: p2p
+              containerPort: 26656
+            - name: telemetry
+              containerPort: 26660
+            - name: pprof
+              containerPort: 6060
+          livenessProbe:
+            httpGet:
+              port: rpc
+              path: /health
+          readinessProbe:
+            exec:
+              command:
+                - /tendermint-readiness
+          volumeMounts:
+            - name: node-home
+              mountPath: /home/
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccountName: blockchain-node
+  volumeClaimTemplates:
+    - metadata:
+        name: node-home
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/scripts/devnet/kubernetes/3-seed/kustomization.yaml
+++ b/scripts/devnet/kubernetes/3-seed/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: local
+resources:
+  - statefulset.yaml
+  - service.yaml

--- a/scripts/devnet/kubernetes/3-seed/service.yaml
+++ b/scripts/devnet/kubernetes/3-seed/service.yaml
@@ -1,0 +1,23 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: seed
+  namespace: local
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: seed
+    app.kubernetes.io/component: node
+    app.kubernetes.io/part-of: elesto
+  ports:
+    - port: 26656
+      name: p2p
+      targetPort: p2p
+    - port: 26657
+      name: rpc
+      targetPort: rpc
+    - port: 26660
+      name: telemetry
+      targetPort: telemetry

--- a/scripts/devnet/kubernetes/3-seed/statefulset.yaml
+++ b/scripts/devnet/kubernetes/3-seed/statefulset.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       initContainers:
         - name: init-seed
-          image: elestod-init:local
+          image: ghcr.io/elesto-dao/elesto-init:22.217-1659728311-910d4da
           command:
             - init-seed.sh
           env:
@@ -46,7 +46,7 @@ spec:
               mountPath: /home/
       containers:
         - name: application
-          image: us-central1-docker.pkg.dev/elesto/elesto/elestod:2.0.0-rc2-snapshots
+          image: ghcr.io/elesto-dao/elesto:22.217-1659728311-910d4da
           args: [
             "start",
             "--db_backend", "memdb",

--- a/scripts/devnet/kubernetes/3-seed/statefulset.yaml
+++ b/scripts/devnet/kubernetes/3-seed/statefulset.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: seed
+  namespace: local
+  labels:
+    app.kubernetes.io/name: seed
+    app.kubernetes.io/component: node
+    app.kubernetes.io/part-of: elesto
+spec:
+  serviceName: seed
+  replicas: 1
+  selector:
+     matchLabels:
+       app.kubernetes.io/name: seed
+       app.kubernetes.io/component: node
+       app.kubernetes.io/part-of: elesto
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: seed
+        app.kubernetes.io/component: node
+        app.kubernetes.io/part-of: elesto
+    spec:
+      initContainers:
+        - name: init-seed
+          image: elestod-init:local
+          command:
+            - init-seed.sh
+          env:
+            - name: CHAIN_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MONIKER
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          #securityContext: # TODO not working
+          #  runAsUser: 20000
+          #  runAsGroup: 20000
+          #  runAsNonRoot: true
+          volumeMounts:
+            - name: node-home
+              mountPath: /home/
+      containers:
+        - name: application
+          image: us-central1-docker.pkg.dev/elesto/elesto/elestod:2.0.0-rc2-snapshots
+          args: [
+            "start",
+            "--db_backend", "memdb",
+            "--grpc.enable", "false",
+            "--grpc-web.enable", "false",
+            "--moniker", "$(MONIKER)",
+            "--home", "/home/",
+            "--pruning", "everything",
+            "--rpc.laddr", "tcp://0.0.0.0:26657",
+            "--p2p.seed_mode", "true",
+          ]
+          env:
+            - name: MONIKER
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ELESTOD_INSTRUMENTATION_PROMETHEUS
+              value: "true"
+            - name: ELESTOD_TX_INDEX_INDEXER
+              value: "null"
+          envFrom:
+            - prefix: ELESTOD_
+              configMapRef:
+                name: seeds-env
+          resources: { }
+          ports:
+            - name: api
+              containerPort: 1317
+            - name: grpc
+              containerPort: 9090
+            - name: grpc-web
+              containerPort: 9091
+            - name: abci
+              containerPort: 26658
+            - name: rpc
+              containerPort: 26657
+            - name: p2p
+              containerPort: 26656
+            - name: telemetry
+              containerPort: 26660
+            - name: pprof
+              containerPort: 6060
+          livenessProbe:
+            httpGet:
+              port: rpc
+              path: /health
+          readinessProbe:
+            exec:
+              command:
+                - /tendermint-readiness
+          volumeMounts:
+            - name: node-home
+              mountPath: /home/
+            - name: genesis
+              mountPath: /home/config/genesis.json
+              subPath: genesis.json
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccountName: blockchain-node
+      volumes:
+        - name: genesis
+          configMap:
+            name: genesis
+        - name: node-home
+          emptyDir: { }

--- a/scripts/devnet/kubernetes/4-validator/kustomization.yaml
+++ b/scripts/devnet/kubernetes/4-validator/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: local
+resources:
+  #- configmap.yaml
+  - statefulset.yaml

--- a/scripts/devnet/kubernetes/4-validator/service.yaml
+++ b/scripts/devnet/kubernetes/4-validator/service.yaml
@@ -1,0 +1,23 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: validators
+  namespace: local
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: validator
+    app.kubernetes.io/component: node
+    app.kubernetes.io/part-of: elesto
+  ports:
+    - port: 26656
+      name: p2p
+      targetPort: p2p
+    - port: 26657
+      name: rpc
+      targetPort: rpc
+    - port: 26660
+      name: telemetry
+      targetPort: telemetry

--- a/scripts/devnet/kubernetes/4-validator/statefulset.yaml
+++ b/scripts/devnet/kubernetes/4-validator/statefulset.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: validator
+  namespace: local
+  labels:
+    app.kubernetes.io/name: validator
+    app.kubernetes.io/component: node
+    app.kubernetes.io/part-of: elesto
+spec:
+  replicas: 3
+  serviceName: validators
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: validator
+      app.kubernetes.io/component: node
+      app.kubernetes.io/part-of: elesto
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: validator
+        app.kubernetes.io/component: node
+        app.kubernetes.io/part-of: elesto
+    spec:
+      initContainers:
+        - name: init-validator
+          image: elestod-init:local
+          command:
+            - init-validator.sh
+          env:
+            - name: CHAIN_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MONIKER
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          #securityContext: # TODO not working
+          #  runAsUser: 20000
+          #  runAsGroup: 20000
+          #  runAsNonRoot: true
+          volumeMounts:
+            - name: node-home
+              mountPath: /home/
+      containers:
+        - name: application
+          image: us-central1-docker.pkg.dev/elesto/elesto/elestod:2.0.0-rc2-snapshots
+          args: [
+            "start",
+            "--moniker", "$(MONIKER)",
+            "--home", "/home/"
+          ]
+          env:
+            - name: MONIKER
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          envFrom:
+            - prefix: ELESTOD_
+              configMapRef:
+                name: validators-env
+          resources: { }
+          ports:
+            - name: api
+              containerPort: 1317
+            - name: grpc
+              containerPort: 9090
+            - name: grpc-web
+              containerPort: 9091
+            - name: abci
+              containerPort: 26658
+            - name: rpc
+              containerPort: 26657
+            - name: p2p
+              containerPort: 26656
+            - name: telemetry
+              containerPort: 26660
+            - name: pprof
+              containerPort: 6060
+          livenessProbe:
+            httpGet:
+              port: rpc
+              path: /health
+          readinessProbe:
+            exec:
+              command:
+                - /tendermint-readiness
+          volumeMounts:
+            - name: node-home
+              mountPath: /home/
+            - name: genesis
+              mountPath: /home/config/genesis.json
+              subPath: genesis.json
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccountName: blockchain-node
+      volumes:
+        - name: genesis
+          configMap:
+            name: genesis
+        - name: node-home
+          emptyDir: { }

--- a/scripts/devnet/kubernetes/4-validator/statefulset.yaml
+++ b/scripts/devnet/kubernetes/4-validator/statefulset.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       initContainers:
         - name: init-validator
-          image: elestod-init:local
+          image: ghcr.io/elesto-dao/elesto-init:22.217-1659728311-910d4da
           command:
             - init-validator.sh
           env:
@@ -46,7 +46,7 @@ spec:
               mountPath: /home/
       containers:
         - name: application
-          image: us-central1-docker.pkg.dev/elesto/elesto/elestod:2.0.0-rc2-snapshots
+          image: ghcr.io/elesto-dao/elesto:22.217-1659728311-910d4da
           args: [
             "start",
             "--moniker", "$(MONIKER)",

--- a/scripts/devnet/kubernetes/4-validator/statefulset.yaml
+++ b/scripts/devnet/kubernetes/4-validator/statefulset.yaml
@@ -49,8 +49,14 @@ spec:
           image: ghcr.io/elesto-dao/elesto:22.217-1659728311-910d4da
           args: [
             "start",
+            "--db_backend", "goleveldb",
+            "--grpc.enable", "false",
+            "--grpc-web.enable", "false",
             "--moniker", "$(MONIKER)",
-            "--home", "/home/"
+            "--home", "/home/",
+            "--log_level", "info",
+            "--pruning", "everything",
+            "--rpc.laddr", "tcp://0.0.0.0:26657"
           ]
           env:
             - name: MONIKER

--- a/scripts/devnet/kubernetes/Makefile
+++ b/scripts/devnet/kubernetes/Makefile
@@ -1,8 +1,8 @@
-INIT_IMAGE_TAG ?= elestod-init:local
-NODE_IMAGE_TAG ?= us-central1-docker.pkg.dev/elesto/elesto/elestod:2.0.0-rc2-snapshots
+INIT_IMAGE_TAG ?= ghcr.io/elesto-dao/elesto-init:22.217-1659728311-910d4da
+NODE_IMAGE_TAG ?= ghcr.io/elesto-dao/elesto:22.217-1659728311-910d4da
 
 k3d-start:
-	k3d cluster create --config k3d.yaml --wait || k3d cluster list | grep elesto
+	k3d cluster create --config k3d.yaml --registry-config registries.yaml --wait || k3d cluster list | grep elesto
 .PHONY: k3d-start
 
 build-init:
@@ -13,7 +13,7 @@ import-images: build-init
 	k3d image import $(INIT_IMAGE_TAG) $(NODE_IMAGE_TAG) --cluster elesto
 .PHONY: import-init
 
-k3d-deploy: import-images
+k3d-deploy:
 	kubectl apply -k . --wait=true
 .PHONY: k3d-deploy
 
@@ -22,5 +22,5 @@ k3d-stop k3d-delete:
 .PHONY:k3d-stop k3d-delete
 
 port-forward:
-	kubectl port-forward --namespace local svc/gensis 26657
+	kubectl port-forward --namespace local svc/genesis 26657
 .PHONY:port-forward

--- a/scripts/devnet/kubernetes/Makefile
+++ b/scripts/devnet/kubernetes/Makefile
@@ -1,0 +1,26 @@
+INIT_IMAGE_TAG ?= elestod-init:local
+NODE_IMAGE_TAG ?= us-central1-docker.pkg.dev/elesto/elesto/elestod:2.0.0-rc2-snapshots
+
+k3d-start:
+	k3d cluster create --config k3d.yaml --wait || k3d cluster list | grep elesto
+.PHONY: k3d-start
+
+build-init:
+	docker build -t $(INIT_IMAGE_TAG) ./0-init/
+.PHONY: build-init
+
+import-images: build-init
+	k3d image import $(INIT_IMAGE_TAG) $(NODE_IMAGE_TAG) --cluster elesto
+.PHONY: import-init
+
+k3d-deploy: import-images
+	kubectl apply -k . --wait=true
+.PHONY: k3d-deploy
+
+k3d-stop k3d-delete:
+	k3d cluster delete --config k3d.yaml
+.PHONY:k3d-stop k3d-delete
+
+port-forward:
+	kubectl port-forward --namespace local svc/gensis 26657
+.PHONY:port-forward

--- a/scripts/devnet/kubernetes/README.md
+++ b/scripts/devnet/kubernetes/README.md
@@ -1,4 +1,4 @@
-# Local blockchain on Kubernetes
+# Create a local blockchain on a Kubernetes cluster
 
 ## Using k3d
 
@@ -9,7 +9,7 @@
 `make port-forward` or `kubectl port-forward --namespace local svc/genesis 26657`
 Then `curl localhost:26657/validators | jq '.result.validators[].address'`
 
-## ER Diagram
+## Entity relationship diagram
 
 ```mermaid
 erDiagram

--- a/scripts/devnet/kubernetes/README.md
+++ b/scripts/devnet/kubernetes/README.md
@@ -2,12 +2,21 @@
 
 ## Using k3d
 
+⚠️ While the elesto repository is private, 
+GitHub credentials are required to access the GitHub Container Registry.
+Copy the `registries.yaml.sample` into `registries.yaml`and replace username, password 
+with an active and valid [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+
 `make k3d-start k3d-deploy`
 
 ## Accessing a node
 
 `make port-forward` or `kubectl port-forward --namespace local svc/genesis 26657`
 Then `curl localhost:26657/validators | jq '.result.validators[].address'`
+
+## Download the genesis file
+
+`kubectl get configmap --namespace local genesis --output jsonpath='{.data.genesis\.json}' | jq`
 
 ## Entity relationship diagram
 

--- a/scripts/devnet/kubernetes/README.md
+++ b/scripts/devnet/kubernetes/README.md
@@ -1,0 +1,20 @@
+# Local blockchain on Kubernetes
+
+## Using k3d
+
+`make k3d-start k3d-deploy`
+
+## Accessing a node
+
+`make port-forward` or `kubectl port-forward --namespace local svc/genesis 26657`
+Then `curl localhost:26657/validators | jq '.result.validators[].address'`
+
+## ER Diagram
+
+```mermaid
+erDiagram
+          Genesis ||--|| Seed : "persistent_peer"
+          Validator }|--|| Genesis : "persistent_peer"
+          Validator }|--|| Seed : "seeds"
+            
+```

--- a/scripts/devnet/kubernetes/k3d.yaml
+++ b/scripts/devnet/kubernetes/k3d.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: k3d.io/v1alpha4
+kind: Simple
+metadata:
+  name: elesto
+servers: 1
+agents: 0
+image: docker.io/rancher/k3s:v1.23.8-k3s1

--- a/scripts/devnet/kubernetes/kind.yaml
+++ b/scripts/devnet/kubernetes/kind.yaml
@@ -1,0 +1,13 @@
+---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: elesto
+nodes:
+  - role: control-plane
+    extraMounts:
+      - hostPath: /Users/glebiller/GolandProjects/elesto/data
+        containerPath: /mnt/data
+    extraPortMappings:
+      - containerPort: 26657
+        hostPort: 26657
+        listenAddress: "127.0.0.1"

--- a/scripts/devnet/kubernetes/kustomization.yaml
+++ b/scripts/devnet/kubernetes/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - 1-common
+  - 2-genesis
+  - 3-seed
+  - 4-validator

--- a/scripts/devnet/kubernetes/registries.yaml.sample
+++ b/scripts/devnet/kubernetes/registries.yaml.sample
@@ -1,0 +1,5 @@
+configs:
+  ghcr.io:
+    auth:
+      username: github-username
+      password: ghp_personal-access-token-key


### PR DESCRIPTION
Add a set of kubernetes manifests to locally start a devnet containing:
* one genesis bootstrapping the chain and acting as a validator
* one seed node having the genesis as private persistent peer
* N (3 by default) validators bootstrap from the genesis node

For the moment it's using a manually deployed docker image of elestod on Google Container Registry.
It would be good to switch to GitHub Container Registry as soon as we start deploying there :)