### PR TITLE
chore: fix linting errors

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -109,7 +109,7 @@ import (
 	minttypes "github.com/elesto-dao/elesto/v2/x/mint/types"
 )
 
-/// Global vars that define account prefix and name of chain
+// Global vars that define account prefix and name of chain
 const (
 	AccountAddressPrefix = "elesto"
 	Name                 = "elesto"

--- a/app/export.go
+++ b/app/export.go
@@ -51,7 +51,7 @@ func (app *App) ExportAppStateAndValidators(
 
 // prepare for fresh start at zero height
 // NOTE zero height genesis is a temporary feature which will be deprecated
-//      in favor of export at a block height
+// in favor of export at a block height
 func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []string) {
 	applyAllowedAddrs := false
 

--- a/x/credential/client/cli/credential.go
+++ b/x/credential/client/cli/credential.go
@@ -222,7 +222,6 @@ func NewMakeCredentialFromSchemaCmd() *cobra.Command {
 	return cmd
 }
 
-//
 func queryPublicCredential(qc credential.QueryClient, credentialID string) (wc *credential.WrappedCredential, err error) {
 	// query the public credential
 	result, err := qc.PublicCredential(
@@ -252,6 +251,7 @@ func (rs revocationStatus) GetBytes() []byte {
 	if err != nil {
 		panic(err)
 	}
+
 	return bs
 }
 

--- a/x/credential/keeper/keeper_test.go
+++ b/x/credential/keeper/keeper_test.go
@@ -60,7 +60,9 @@ func (suite *KeeperTestSuite) SetupTest() {
 	ms.MountStoreWithDB(keyAcc, sdk.StoreTypeIAVL, db)
 	_ = ms.LoadLatestVersion()
 
-	ctx := sdk.NewContext(ms, tmproto.Header{ChainID: "foochainid"}, true, server.ZeroLogWrapper{log.Logger})
+	ctx := sdk.NewContext(ms, tmproto.Header{ChainID: "foochainid"}, true,
+		server.ZeroLogWrapper{Logger: log.Logger},
+	)
 
 	interfaceRegistry := ct.NewInterfaceRegistry()
 	authtypes.RegisterInterfaces(interfaceRegistry)

--- a/x/did/client/cli/aries.go
+++ b/x/did/client/cli/aries.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -35,7 +34,7 @@ func request(method, url string, requestBody io.Reader, val interface{}) (err er
 		return
 	}
 	defer resp.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return
 	}

--- a/x/did/did.go
+++ b/x/did/did.go
@@ -327,7 +327,7 @@ func WithVerifications(verifications ...*Verification) DocumentOption {
 	}
 }
 
-//WithServices add optional services
+// WithServices add optional services
 func WithServices(services ...*Service) DocumentOption {
 	return func(did *DidDocument) error {
 		return did.AddServices(services...)

--- a/x/did/keeper/keeper_test.go
+++ b/x/did/keeper/keeper_test.go
@@ -39,7 +39,9 @@ func (suite *KeeperTestSuite) SetupTest() {
 	ms.MountStoreWithDB(memKeyDidDocument, sdk.StoreTypeIAVL, db)
 	_ = ms.LoadLatestVersion()
 
-	ctx := sdk.NewContext(ms, tmproto.Header{ChainID: "foochainid"}, true, server.ZeroLogWrapper{log.Logger})
+	ctx := sdk.NewContext(ms, tmproto.Header{ChainID: "foochainid"}, true,
+		server.ZeroLogWrapper{Logger: log.Logger},
+	)
 
 	interfaceRegistry := ct.NewInterfaceRegistry()
 	marshaler := codec.NewProtoCodec(interfaceRegistry)


### PR DESCRIPTION
Fix linter/`go vet` issues found around the codebase, following Oak's recommendations: https://github.com/oak-security/resources/blob/main/checklists/Go%20Audit%20Checklist.pdf